### PR TITLE
Makefile mod for cleanup build

### DIFF
--- a/extension/firefox/Makefile
+++ b/extension/firefox/Makefile
@@ -50,7 +50,7 @@ build: clean
 	mkdir build/content/lib/DataView.js
 	cp ../../lib/DataView.js/* build/content/lib/DataView.js/
 	# Removing hidden files
-	-find build -name ".DS_Store" | xargs rm
+	-find build -name ".DS_Store" -exec rm {} \;
 	# Packaging XPI file
 	cd build; zip -r shumway.xpi *
 

--- a/web/Makefile
+++ b/web/Makefile
@@ -54,7 +54,7 @@ build: clean \
 	cp $(SHUMWAY_ROOT)/extension/firefox/build/shumway.xpi build/extension/firefox/
 	cp $(SHUMWAY_ROOT)/extension/firefox/build/update.rdf build/extension/firefox/
 	# Removing hidden files
-	-find build -name ".DS_Store" | xargs rm
+	-find build -name ".DS_Store" -exec rm {} \;
 	# Creating commit
 	cd build; git init .; git checkout -b gh-pages;
 	cd build; git add -A; git commit -m "Updates shumway gh-pages files"


### PR DESCRIPTION
The old cleanup command was not capable of handling odd spaces and
strange characters sometimes found in Mac.  This command does.
