### PR TITLE
Fix build with gcc 4.7

### DIFF
--- a/utils/Makefile
+++ b/utils/Makefile
@@ -63,6 +63,7 @@ $(TAMARIN_HOME)/configure.py:
 	hg clone $(TAMARIN_URL) $(TAMARIN_HOME)
 	cd $(TAMARIN_HOME); patch -p 1 < ../patches/tamarin-108-fix.patch
 	cd $(TAMARIN_HOME); patch -p 1 < ../patches/tamarin-npexp-fix.patch
+	cd $(TAMARIN_HOME); patch -p 1 < ../patches/tamarin-gcc47-fix.patch
 
 build-tamarin-tests:
 	cd $(TAMARIN_HOME)/test/acceptance; ASC=../../../$(ASC_JAR) BUILTINABC=../../generated/builtin.abc SHELLABC=../../generated/shell_toplevel.abc AVM=../../bin/shell/avmshell python runtests.py --threads=$(THREADS) --rebuildtests

--- a/utils/patches/tamarin-gcc47-fix.patch
+++ b/utils/patches/tamarin-gcc47-fix.patch
@@ -1,0 +1,11 @@
+--- a/configure.py
++++ b/configure.py
+@@ -104,6 +108,8 @@
+             FLAGS += "-Werror -Wempty-body -Wno-logical-op -Wmissing-field-initializers -Wstrict-aliasing=3 -Wno-array-bounds -Wno-clobbered -Wstrict-overflow=0 -funit-at-a-time  "
+             if (MAJOR_VERSION == 4 and MINOR_VERSION == 6): # 4.6
+                 FLAGS += "-Wno-psabi -Wno-unused-variable -Wno-unused-but-set-variable "
++            if (MAJOR_VERSION == 4 and MINOR_VERSION == 7): # 4.7
++                FLAGS += "-Wno-unused-but-set-variable -Wno-narrowing "
+ 
+     return FLAGS
+ 


### PR DESCRIPTION
If gcc 4.7, it ignores unused-but-set-variable and narrowing warnings.
