### PR TITLE
Prevent Namespace conflicts

### DIFF
--- a/src/avm2/native.js
+++ b/src/avm2/native.js
@@ -856,16 +856,16 @@ var natives = (function () {
        * XXX: Not sure if this is right for whatever E4X bullshit this is used
        * for.
        */
-      var ns = Namespace.createNamespace(uriValue);
+      var ns = ShumwayNamespace.createNamespace(uriValue);
       ns.prefix = prefixValue;
 
       return ns;
     }
 
     var c = new runtime.domain.system.Class("Namespace", ASNamespace, C(ASNamespace));
-    c.extendNative(baseClass, Namespace);
+    c.extendNative(baseClass, ShumwayNamespace);
 
-    var Np = Namespace.prototype;
+    var Np = ShumwayNamespace.prototype;
     c.native = {
       instance: {
         prefix: {

--- a/src/avm2/parser.js
+++ b/src/avm2/parser.js
@@ -239,7 +239,7 @@ var Trait = (function () {
   return trait;
 })();
 
-var Namespace = (function () {
+var ShumwayNamespace = (function () {
 
   var kinds = {};
   kinds[CONSTANT_Namespace] = "public";
@@ -645,7 +645,7 @@ var Multiname = (function () {
       name = simpleName;
       namespace = "";
     }
-    return simpleNameCache[simpleName] = new Multiname(Namespace.fromSimpleName(namespace), name);
+    return simpleNameCache[simpleName] = new Multiname(ShumwayNamespace.fromSimpleName(namespace), name);
   };
 
   multiname.prototype.getQName = function getQName(index) {
@@ -789,7 +789,7 @@ var ConstantPool = (function constantPool() {
     var namespaces = [undefined];
     n = stream.readU30();
     for (i = 1; i < n; ++i) {
-      var namespace = new Namespace();
+      var namespace = new ShumwayNamespace();
       namespace.parse(this, stream);
       namespaces.push(namespace);
     }


### PR DESCRIPTION
Turns out E4X provides a class called "Namespace" that conflicts with our class called "Namespace". If we actually had Namespaces, this wouldn't be a problem, but we just pollute the global namespace, so I'm just going to prefix the class name.
