### PR TITLE
Fixes slow construction of heavy sprites.

### DIFF
--- a/src/flash/display/Loader.js
+++ b/src/flash/display/Loader.js
@@ -443,7 +443,7 @@ var LoaderDefinition = (function () {
       var dictionary = loader._dictionary;
       var labelName = frame.labelName;
 
-      displayList = Object.create(displayList);
+      displayList = cloneObject(displayList);
 
       var depths = frame.depths;
       if (depths) {
@@ -452,7 +452,7 @@ var LoaderDefinition = (function () {
           if (cmd) {
             if (displayList[depth] && cmd.move) {
               var oldCmd = cmd;
-              cmd = Object.create(displayList[depth]);
+              cmd = cloneObject(displayList[depth]);
               for (var prop in oldCmd) {
                 var val = oldCmd[prop];
                 if (val)
@@ -465,9 +465,8 @@ var LoaderDefinition = (function () {
               if (itemPromise && !itemPromise.resolved)
                 promiseQueue.push(itemPromise);
 
-              cmd = Object.create(cmd, {
-                promise: { value: itemPromise }
-              });
+              cmd = cloneObject(cmd);
+              cmd.promise = itemPromise;
             }
           }
           displayList[depth] = cmd;

--- a/src/flash/util.js
+++ b/src/flash/util.js
@@ -27,6 +27,13 @@ function scriptProperties(namespace, props) {
   }, {});
 }
 
+function cloneObject(obj) {
+  var clone = Object.create(null);
+  for (var prop in obj)
+    clone[prop] = obj[prop];
+  return clone;
+}
+
 function Promise() {
   this.resolved = false;
   this._callbacks = [];


### PR DESCRIPTION
Speeds up sprite construction by cloning display command lists instead of chaining them with Object.create.
