### PR TITLE
Replacing const to var for IE10

### DIFF
--- a/src/avm2/native.js
+++ b/src/avm2/native.js
@@ -1791,12 +1791,12 @@ var natives = (function () {
     }
     
     function addTraits(cls, flags) {
-      const includedMembers = [flags & Flags.INCLUDE_VARIABLES,
+      var includedMembers = [flags & Flags.INCLUDE_VARIABLES,
                                flags & Flags.INCLUDE_METHODS,
                                flags & Flags.INCLUDE_ACCESSORS,
                                flags & Flags.INCLUDE_ACCESSORS];
-      const includeBases = flags & Flags.INCLUDE_BASES;
-      const includeMetadata = flags & Flags.INCLUDE_METADATA;
+      var includeBases = flags & Flags.INCLUDE_BASES;
+      var includeMetadata = flags & Flags.INCLUDE_METADATA;
 
       var obj = {};
 


### PR DESCRIPTION
replacing const to var
