### PR TITLE
Changes `make server` to add no-cache headers to all responses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ hello-world:
 IRC_ROOM = shumway-build-bot
 
 server:
-	python -m SimpleHTTPServer
+	python utils/webserver.py
 
 push-test:
 	git pull origin master

--- a/utils/webserver.py
+++ b/utils/webserver.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+import SimpleHTTPServer
+ 
+class MyHTTPRequestHandler(SimpleHTTPServer.SimpleHTTPRequestHandler):
+	def end_headers(self):
+		self.send_my_headers()
+		SimpleHTTPServer.SimpleHTTPRequestHandler.end_headers(self)
+	 
+	def send_my_headers(self):
+		self.send_header("Cache-Control", "no-cache, no-store, must-revalidate")
+		self.send_header("Pragma", "no-cache")
+		self.send_header("Expires", "0")
+ 
+ 
+if __name__ == '__main__':
+	SimpleHTTPServer.test(HandlerClass=MyHTTPRequestHandler)


### PR DESCRIPTION
Required to force Firefox to update SWF files loaded via XMLHTTPRequest
