### PR TITLE
Removes redundant fields and arguments around handling of dimensions

### DIFF
--- a/src/flash/display/DisplayObject.js
+++ b/src/flash/display/DisplayObject.js
@@ -72,13 +72,9 @@ var DisplayObjectDefinition = (function () {
       this._visible = true;
       this._hidden = false;
       this._wasCachedAsBitmap = false;
-      this._x = 0;
-      this._y = 0;
       this._destroyed = false;
       this._maskedObject = null;
       this._scrollRect = null;
-      this._width = null;
-      this._height = null;
       this._invalid = false;
       this._region = null;
       this._level = -1;
@@ -144,8 +140,6 @@ var DisplayObjectDefinition = (function () {
           this._scaleX = a > 0 ? sx : -sx;
           var sy = Math.sqrt(d * d + c * c);
           this._scaleY = d > 0 ? sy : -sy;
-          this._x = matrix.tx|0;
-          this._y = matrix.ty|0;
 
           this._currentTransform = matrix;
         }
@@ -335,8 +329,6 @@ var DisplayObjectDefinition = (function () {
       transform.b = v * scaleX;
       transform.c = -v * scaleY;
       transform.d = u * scaleY;
-      transform.tx = this._x|0;
-      transform.ty = this._y|0;
     },
 
     get accessibilityProperties() {
@@ -395,11 +387,6 @@ var DisplayObjectDefinition = (function () {
     },
     set height(val) {
       if (val < 0) {
-        return;
-      }
-
-      if (this._height !== null) {
-        this._height = val;
         return;
       }
 
@@ -603,11 +590,6 @@ var DisplayObjectDefinition = (function () {
         return;
       }
 
-      if (this._width !== null) {
-        this._width = val;
-        return;
-      }
-
       var rotation = this._rotation / 180 * Math.PI;
       var u = Math.abs(Math.cos(rotation));
       var v = Math.abs(Math.sin(rotation));
@@ -625,30 +607,30 @@ var DisplayObjectDefinition = (function () {
       this.scaleX = val / baseWidth;
     },
     get x() {
-      return this._x;
+      return this._currentTransform.tx;
     },
     set x(val) {
-      if (val === this._x) {
+      if (val === this._currentTransform.tx) {
         return;
       }
 
       this._invalidate();
       this._invalidateBounds();
 
-      this._x = this._currentTransform.tx = val;
+      this._currentTransform.tx = val;
     },
     get y() {
-      return this._y;
+      return this._currentTransform.ty;
     },
     set y(val) {
-      if (val === this._y) {
+      if (val === this._currentTransform.ty) {
         return;
       }
 
       this._invalidate();
       this._invalidateBounds();
 
-      this._y = this._currentTransform.ty = val;
+      this._currentTransform.ty = val;
     },
     get z() {
       return 0;

--- a/src/flash/display/MovieClip.js
+++ b/src/flash/display/MovieClip.js
@@ -176,8 +176,6 @@ var MovieClipDefinition = (function () {
             currentChild._scaleX = a > 0 ? sx : -sx;
             var sy = Math.sqrt(d * d + c * c);
             currentChild._scaleY = d > 0 ? sy : -sy;
-            var x = currentChild._x = m.tx;
-            var y = currentChild._y = m.ty;
 
             currentChild._currentTransform = m;
           }

--- a/src/flash/geom/Transform.js
+++ b/src/flash/geom/Transform.js
@@ -89,8 +89,6 @@ var TransformDefinition = (function () {
       target._scaleX = a > 0 ? sx : -sx;
       var sy = Math.sqrt(d * d + c * c);
       target._scaleY = d > 0 ? sy : -sy;
-      target._x = tx;
-      target._y = ty;
 
       target._currentTransform = {
         a: a,

--- a/src/swf/renderer.js
+++ b/src/swf/renderer.js
@@ -242,7 +242,7 @@ RenderVisitor.prototype = {
 
     if (clippingMask && isContainer) {
       ctx.save();
-      renderDisplayObject(child, ctx, child._currentTransform, context);
+      renderDisplayObject(child, ctx, context);
       for (var i = 0, n = child._children.length; i < n; i++) {
         var child1 = child._children[i];
         if (!child1) {
@@ -281,7 +281,7 @@ RenderVisitor.prototype = {
       tempCanvas = CanvasCache.getCanvas(ctx.canvas);
       tempCtx = tempCanvas.ctx;
       tempCtx.currentTransform = ctx.currentTransform;
-      renderDisplayObject(child, tempCtx, child._currentTransform, context);
+      renderDisplayObject(child, tempCtx, context);
 
       if (isContainer) {
         this.ctx = tempCtx;
@@ -301,7 +301,7 @@ RenderVisitor.prototype = {
       CanvasCache.releaseCanvas(tempCanvas);
       CanvasCache.releaseCanvas(maskCanvas);
     } else {
-      renderDisplayObject(child, ctx, child._currentTransform, context);
+      renderDisplayObject(child, ctx, context);
 
       if (isContainer) {
         visitContainer(child, this, context);
@@ -424,9 +424,9 @@ function RenderingContext(refreshStage, invalidPath) {
   this.colorTransform = new RenderingColorTransform();
 }
 
-function renderDisplayObject(child, ctx, transform, context) {
-  if (transform) {
-    var m = transform;
+function renderDisplayObject(child, ctx, context) {
+  var m = child._currentTransform;
+  if (m) {
     if (m.a * m.d == m.b * m.c) {
       // Workaround for bug 844184 -- the object is invisible
       ctx.closePath();


### PR DESCRIPTION
Specifically, DisplayObject._x, _y, _width and _height are removed, as they're never actually read, but painstakingly kept in sync with they respective values on _currentTransform.

Also, renderDisplayObject only ever uses the given element's _currentTransform, so there's no need to pass that in explicitly.
