### PR TITLE
Temporary workaround for bug 920927

### DIFF
--- a/extension/firefox/components/FlashStreamConverter.js
+++ b/extension/firefox/components/FlashStreamConverter.js
@@ -664,6 +664,9 @@ FlashStreamConverterBase.prototype = {
         tagName = element.nodeName;
       }
 
+      // TODO: remove hack once bug 920927 is fixed
+      element.style.visibility = 'visible';
+
       pageUrl = element.ownerDocument.location.href; // proper page url?
 
       if (tagName == 'EMBED') {


### PR DESCRIPTION
... which makes the Firefox extension not show content when Ask To Activate is active for Flash
