### PR TITLE
Fixes various TextField layout issues and adds support for more TextField properties

### DIFF
--- a/src/flash/text/TextField.js
+++ b/src/flash/text/TextField.js
@@ -503,6 +503,8 @@ var TextFieldDefinition = (function () {
       }
       initialFormat.str = makeFormatString(initialFormat);
 
+      this._embedFonts = !!tag.useOutlines;
+
       switch (tag.align) {
         case 1: initialFormat.align = 'right'; break;
         case 2: initialFormat.align = 'center'; break;


### PR DESCRIPTION
Specifically, the following properties are newly supported:
- numLines
- maxScrollH
- maxScrollV

Also, plain text is now always rendered with line breaks intact, because as it turns out, TextField#multiline = false only prevents line breaks for text input _and_ html text. Who would've though.
