### PR TITLE
target argument of MovieClipLoader#loadClip and unloadClip may be level

### DIFF
--- a/src/avm2/generated/avm1lib/AS2MovieClipLoader.as
+++ b/src/avm2/generated/avm1lib/AS2MovieClipLoader.as
@@ -37,7 +37,8 @@ package avm1lib {
     public function loadClip(url: String, target: Object) : Boolean
     {
       var nativeObject = this.$nativeObject;
-      var nativeTarget = AS2Utils.resolveTarget(target);
+      var nativeTarget = typeof target === 'number' ?
+        AS2Utils.resolveLevel(target) : AS2Utils.resolveTarget(target);
       nativeTarget.$nativeObject.addChild(nativeObject);
       nativeObject.load(new flash.net.URLRequest(url));
     }
@@ -52,7 +53,8 @@ package avm1lib {
     public function unloadClip(target: Object) : Boolean
     {
       var nativeObject = this.$nativeObject;
-      var nativeTarget = AS2Utils.resolveTarget(target);
+      var nativeTarget = typeof target === 'number' ?
+        AS2Utils.resolveLevel(target) : AS2Utils.resolveTarget(target);
       nativeTarget.$nativeObject.removeChild(nativeObject);
     }
 


### PR DESCRIPTION
According to the document[1,2], "target" argument of these methods may
be number (level).

1: http://help.adobe.com/en_US/AS2LCR/Flash_10.0/help.html?content=00001381.html
2: http://help.adobe.com/en_US/AS2LCR/Flash_10.0/help.html?content=00001389.html
