### PR TITLE
Fixes #819 (Regression: Mushroomer is missing level backgrounds)

### DIFF
--- a/src/flash/display/Bitmap.js
+++ b/src/flash/display/Bitmap.js
@@ -39,6 +39,8 @@ var BitmapDefinition = (function () {
       this._bbox = { xMin: 0, yMin: 0, xMax: 0, yMax: 0 };
     }
     this._invalidate();
+    this._invalidateBounds();
+    this._invalidateTransform();
   }
 
   return {


### PR DESCRIPTION
Bitmap bounds were not invalidated after setting bitmapData
