### PR TITLE
Added Tabzilla To Top Of The Page.

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,9 +4,10 @@
   <title>Shumway</title>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
   <link rel="stylesheet" href="main.css">
+  <link href="//mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" rel="stylesheet" />
 </head>
 <body>
-<a href="http://mozilla.org"><img width="118" height="68" style="position: absolute; top: 0; left: 50; border: 0;" src="images/mozilla.png" alt="Mozilla"></a>
+<a href="/en-US/" id="tabzilla">mozilla</a>
 <a href="http://github.com/mozilla/shumway"><img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
 <div id="container">
   <div id="flashContent">
@@ -53,7 +54,8 @@
       by running:
     <pre>$ git clone git://github.com/mozilla/shumway</pre>
     </p>
-  </div>
+  </div
+  <script src="//mozorg.cdn.mozilla.net/tabzilla/tabzilla.js"></script>
 </div>
 </body>
 </html>


### PR DESCRIPTION
Steps followed:
1. Added the static tab link (example below) to the top of index.html 
<a href="/en-US/" id="tabzilla">mozilla</a>
2. Included the tabzilla.css CSS file either as a CSS include
<link href="//mozorg.cdn.mozilla.net/media/css/tabzilla-min.css" rel="stylesheet" />
3. Included thetabzilla.js file in template in the footer. 

<script src="//mozorg.cdn.mozilla.net/tabzilla/tabzilla.js"></script>
# Importance

As per says in styleguide:
"Tabzilla is our name for the universal tab that appears on the top of all Mozilla websites (like this one!). It expands to reveal site navigation as well as a promo area (on desktop) and should be a part of any Mozilla-related Web property you’re building. To that end, you’ll find a simple set of HTML/CSS/JS instructions on this page for easy implementation."
link: http://www.mozilla.org/en-US/styleguide/websites/sandstone/tabzilla/
