### PR TITLE
Prevent Soundcloud's player from breaking

### DIFF
--- a/extension/firefox/content/ShumwayStreamConverter.jsm
+++ b/extension/firefox/content/ShumwayStreamConverter.jsm
@@ -177,7 +177,8 @@ function isShumwayEnabledFor(actions) {
 
   // blacklisting well known sites with issues
   if (/\.ytimg\.com\//i.test(url) /* youtube movies */ ||
-    /\/vui.swf\b/i.test(url) /* vidyo manager */ ) {
+    /\/vui.swf\b/i.test(url) /* vidyo manager */  ||
+    /soundcloud\.com\/player\/assets\/swf/i.test(url)) {
     return false;
   }
 


### PR DESCRIPTION
Adds Soundcloud's SWF for audio to the blacklist.

These blacklists should probably be moved to some sort of configuration. It's currently impossible to elect to use the Flash Player as the Flash object is too small to properly render both Shumway and Flash buttons.
