### PR TITLE
remove assert in scaleAlphaChannel

### DIFF
--- a/src/swf/filters/filter.js
+++ b/src/swf/filters/filter.js
@@ -174,7 +174,6 @@ function alphaFilter(buffer, color) {
 }
 
 function scaleAlphaChannel(buffer, value) {
-  assert (isNumeric(value));
   for (var ptr = 0, end = buffer.length; ptr < end; ptr += 4) {
     buffer[ptr + 3] *= value;
   }


### PR DESCRIPTION
If you open up examples/filter/filter.html, the shadow filter is broken (the color doesn't run either but that's because a JS error is thrown from the shadow filter).

The problem is that the filter driver is calling `dropShadowFilter` with a `strength` of .5, which is being passed to `scaleAlphaChannel` in filter.js. `isNumeric` actually enforce integral types, so it fails, but I bet it used to accept all numeric types and this assert is leftover.
