### PR TITLE
Caches often used bitmapdata

### DIFF
--- a/src/flash/display/Bitmap.js
+++ b/src/flash/display/Bitmap.js
@@ -65,7 +65,7 @@ var BitmapDefinition = (function () {
       colorTransform.setAlpha(ctx, true);
       ctx.imageSmoothingEnabled = ctx.mozImageSmoothingEnabled =
                                   this._smoothing;
-      ctx.drawImage(this._bitmapData._drawable, 0, 0);
+      ctx.drawImage(this._bitmapData._getDrawable(), 0, 0);
       ctx.imageSmoothingEnabled = ctx.mozImageSmoothingEnabled = false;
       ctx.restore();
       traceRenderer.value && frameWriter.writeLn("Bitmap.draw() snapping: " + this._pixelSnapping +


### PR DESCRIPTION
Based on https://bugzilla.mozilla.org/show_bug.cgi?id=935688 suggestion

So idea after 10 times canvas is requested, it starts returing html img. And resets after canvas is modified
