### PR TITLE
Coerce to trait type when setting properties.

### DIFF
--- a/src/avm2/compiler/builder.js
+++ b/src/avm2/compiler/builder.js
@@ -719,6 +719,10 @@ var createName = function createName(namespaces, name) {
           release || assert (multiname instanceof IR.ASMultiname);
           if (ti) {
             if (ti.trait) {
+              var coercer = ti.trait.typeName ? getCoercerForType(ti.trait.typeName) : null;
+              if (coercer) {
+                value = coercer(value);
+              }
               store(new IR.SetProperty(region, state.store, object, qualifiedNameConstant(ti.trait.name), value));
               return;
             }

--- a/src/avm2/runtime.js
+++ b/src/avm2/runtime.js
@@ -377,6 +377,16 @@ function asSetProperty(namespaces, name, flags, value) {
   if (this.asSetNumericProperty && Multiname.isNumeric(resolved)) {
     return this.asSetNumericProperty(resolved, value);
   }
+  var slotInfo = this[VM_SLOTS].byQN[resolved];
+  if (slotInfo) {
+    if (slotInfo.const) {
+      return;
+    }
+    var type = slotInfo.type;
+    if (type && type.coerce) {
+      value = type.coerce(value);
+    }
+  }
   this[resolved] = value;
 }
 
@@ -683,16 +693,16 @@ function publicizeProperties(object) {
 }
 
 function asGetSlot(object, index) {
-  return object[object[VM_SLOTS][index].name];
+  return object[object[VM_SLOTS].byID[index].name];
 }
 
 function asSetSlot(object, index, value) {
-  var binding = object[VM_SLOTS][index];
-  if (binding.const) {
+  var slotInfo = object[VM_SLOTS].byID[index];
+  if (slotInfo.const) {
     return;
   }
-  var name = binding.name;
-  var type = binding.type;
+  var name = slotInfo.name;
+  var type = slotInfo.type;
   if (type && type.coerce) {
     object[name] = type.coerce(value);
   } else {

--- a/src/avm2/tests/regress/correctness/pass/trait-types-0.as
+++ b/src/avm2/tests/regress/correctness/pass/trait-types-0.as
@@ -1,0 +1,29 @@
+package {
+  class A {
+    var i : int;
+    var u : uint;
+    var n : Number;
+    var b : Boolean;
+  }
+
+  (function () {
+    var a = new A();
+    a.i = 2.5; trace(a.i);
+    a.i = "23.45"; trace(a.i);
+    a.u = -10; trace(a.u);
+    a.n = "0x123"; trace(a.n);
+    a.b = "YEP"; trace(a.b);
+    a.b = ""; trace(a.b);
+  })();
+
+  (function (a) {
+    a.i = 2.5; trace(a.i);
+    a.i = "23.45"; trace(a.i);
+    a.u = -10; trace(a.u);
+    a.n = "0x123"; trace(a.n);
+    a.b = "YEP"; trace(a.b);
+    a.b = ""; trace(a.b)
+  })(new A());
+
+  trace("-- DONE --");
+}


### PR DESCRIPTION
This can slow down asSetProperty since the extra coercion is needed, but hopefully the verifier can eliminate some of this overhead.
