### PR TITLE
Re-enable 3_joystick test

### DIFF
--- a/test/swfs/3_joystick.stas
+++ b/test/swfs/3_joystick.stas
@@ -1,7 +1,7 @@
 // 3_joystick.swf test script
 
 run_test = function (t, file) {
-  var initx = 115.1, inity = 116, delta = 70;
+  var initx = 115.1, inity = 116, delta = 20;
   print ("Testing " + file);
   t.reset (file);
   var expected = Buffer.load (file + ".trace");

--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -264,6 +264,13 @@
        ],
        "type": "stas"
     },
+    {  "id": "3_joystick",
+       "stas": "swfs/3_joystick.stas",
+       "filenames": [
+         "swfs/3_joystick.swf"
+       ],
+       "type": "stas"
+    },
     {  "id": "MaskTest",
        "frames": [1],
        "swf": "swfs/MaskTest.swf",


### PR DESCRIPTION
Fixed failures by making the bug's movement slower, causing just one "wrap" message to be traced.
