### PR TITLE
Ignore mouse events on HUD display

### DIFF
--- a/src/swf/renderer.js
+++ b/src/swf/renderer.js
@@ -633,7 +633,7 @@ function initializeHUD(stage, parentCanvas) {
   canvasContainer.style.width = "100%";
   canvasContainer.style.height = "150px";
   canvasContainer.style.backgroundColor = "rgba(0, 0, 0, 0.4)";
-  // canvasContainer.style.pointerEvents = canvas.style.pointerEvents = "none";
+  canvasContainer.style.pointerEvents = "none";
   parentCanvas.parentElement.appendChild(canvasContainer);
   hudTimeline = new Timeline(canvas);
   hudTimeline.setFrameRate(stage._frameRate);


### PR DESCRIPTION
So, applying this to just the container, not the canvas, too, works.
