### PR TITLE
Fix compile error in GestureEvent, and link native impl

### DIFF
--- a/src/flash.ts/events/GestureEvent.ts
+++ b/src/flash.ts/events/GestureEvent.ts
@@ -103,5 +103,16 @@ module Shumway.AVM2.AS.flash.events {
       somewhatImplemented("public flash.events.GestureEvent::updateAfterEvent");
       return;
     }
+
+    private NativeCtor(phase: string = null, localX: number = 0, localY: number = 0,
+                       ctrlKey: boolean = false, altKey: boolean = false, shiftKey: boolean = false)
+    {
+      this._phase = asCoerceString(phase);
+      this._localX = +localX;
+      this._localY = +localY;
+      this._ctrlKey = !!ctrlKey;
+      this._altKey = !!altKey;
+      this._shiftKey = !!shiftKey;
+    }
   }
 }

--- a/src/flash.ts/linker.ts
+++ b/src/flash.ts/linker.ts
@@ -61,6 +61,7 @@ module Shumway.AVM2.AS {
     M("flash.events.IOErrorEvent"),
     M("flash.events.KeyboardEvent", "KeyboardEventClass", flash.events.KeyboardEvent),
     M("flash.events.MouseEvent", "MouseEventClass", flash.events.MouseEvent),
+    M("flash.events.GestureEvent", "GestureEventClass", flash.events.GestureEvent),
     M("flash.events.TextEvent", "TextEventClass", flash.events.TextEvent),
     M("flash.events.TimerEvent", "TimerEventClass", flash.events.TimerEvent),
     M("flash.events.ProgressEvent", "ProgressEventClass", flash.events.ProgressEvent),

--- a/src/flash/events/GestureEvent.as
+++ b/src/flash/events/GestureEvent.as
@@ -18,11 +18,15 @@ package flash.events {
 [native(cls='GestureEventClass')]
 public class GestureEvent extends Event {
   public static const GESTURE_TWO_FINGER_TAP: String = "gestureTwoFingerTap";
-  public native function GestureEvent(type: String, bubbles: Boolean = true,
+  public function GestureEvent(type: String, bubbles: Boolean = true,
                                       cancelable: Boolean = false, phase: String = null,
                                       localX: Number = 0, localY: Number = 0,
                                       ctrlKey: Boolean = false, altKey: Boolean = false,
-                                      shiftKey: Boolean = false);
+                                      shiftKey: Boolean = false)
+  {
+    super(type, bubbles, cancelable);
+    NativeCtor(phase, localX, localY, ctrlKey, altKey, shiftKey);
+  }
 
   public native function get localX(): Number;
   public native function set localX(value: Number): void;
@@ -51,5 +55,10 @@ public class GestureEvent extends Event {
                           'localY', 'ctrlKey', 'altKey', 'shiftKey');
   }
   public native function updateAfterEvent(): void;
+
+  private native function NativeCtor(phase: String = null,
+                                     localX: Number = 0, localY: Number = 0,
+                                     ctrlKey: Boolean = false, altKey: Boolean = false,
+                                     shiftKey: Boolean = false): void;
 }
 }


### PR DESCRIPTION
It looks like the abc compiler has a bug that makes it impossible to make constructors native for classes that extend other classes with a non-default ctor: the compiler complains about the correct `super` call missing, even though there isn't a function body that could contain the `super` call in the first place.
