### PR TITLE
Very rough implementation of passing shape data from Graphics objects to the rendering backend

### DIFF
--- a/src/gfx/references.ts
+++ b/src/gfx/references.ts
@@ -16,6 +16,7 @@
 
 /// <reference path='../utilities.ts' />
 /// <reference path='utilities.ts' />
+/// <reference path='../avm2/natives/byteArray.ts' />
 /// <reference path='shapes.ts'/>
 /// <reference path='geometry.ts'/>
 /// <reference path='regionAllocator.ts'/>

--- a/src/gfx/stage.ts
+++ b/src/gfx/stage.ts
@@ -8,6 +8,7 @@ module Shumway.GFX {
   import TileCache = Geometry.TileCache;
   import Tile = Geometry.Tile;
   import OBB = Geometry.OBB;
+  import IDataInput = Shumway.AVM2.AS.flash.utils.IDataInput;
 
   export enum BlendMode {
     Normal     = 1,
@@ -178,6 +179,9 @@ module Shumway.GFX {
 
   export class Shape extends Frame {
     source: IRenderable;
+
+    private fillStyle: ColorStyle;
+    private data: IDataInput;
     constructor(source: IRenderable) {
       super();
       this.source = source;
@@ -185,6 +189,31 @@ module Shumway.GFX {
 
     public getBounds(): Rectangle {
       return this.source.getBounds();
+    }
+
+    public ensureSource(data: IDataInput, bounds: Rectangle): void {
+      if (this.source) {
+        return;
+      }
+      this.data = data;
+      this.source = new Renderable(bounds, this._render.bind(this));
+    }
+
+    private _render(context: CanvasRenderingContext2D): void {
+      if (!this.fillStyle) {
+        this.fillStyle = ColorStyle.randomStyle();
+      }
+      var bounds = this.getBounds();
+      context.save();
+      context.beginPath();
+      context.lineWidth = 2;
+      context.fillStyle = this.fillStyle;
+      context.fillRect(bounds.x, bounds.y, bounds.w, bounds.h);
+      context.restore();
+      this.source.isInvalid = false;
+      this.source.isScalable = true;
+      this.source.isTileable = true;
+      this.source.isDynamic = false;
     }
   }
 

--- a/src/player/player.ts
+++ b/src/player/player.ts
@@ -99,9 +99,11 @@ module Shumway {
     }
 
     private _pumpDisplayListUpdates(): void {
-      var byteArray = new ByteArray();
+      var updates = new ByteArray();
+      var assets = new Array<ByteArray>();
       var serializer = new Shumway.Remoting.Client.ChannelSerializer();
-      serializer.output = byteArray;
+      serializer.output = updates;
+      serializer.outputAssets = assets;
 
       serializer.writeReferences = false;
       serializer.clearDirtyBits = false;
@@ -111,11 +113,12 @@ module Shumway {
       serializer.clearDirtyBits = true;
       serializer.writeStage(this._stage);
 
-      byteArray.writeInt(Shumway.Remoting.MessageTag.EOF);
-      byteArray.position = 0;
+      updates.writeInt(Shumway.Remoting.MessageTag.EOF);
+      updates.position = 0;
 
       var deserializer = new Remoting.Server.ChannelDeserializer();
-      deserializer.input = byteArray;
+      deserializer.input = updates;
+      deserializer.inputAssets = assets;
       deserializer.context = this._context;
       deserializer.read();
     }

--- a/src/player/remoting.ts
+++ b/src/player/remoting.ts
@@ -19,7 +19,8 @@ module Shumway.Remoting {
     HasBounds                   = 0x0002,
     HasChildren                 = 0x0004,
     HasColorTransform           = 0x0008,
-    HasMiscellaneousProperties  = 0x0010
+    HasMiscellaneousProperties  = 0x0010,
+    HasShapeData                = 0x0020
   }
 
   export enum MessageTag {

--- a/src/player/remotingClient.ts
+++ b/src/player/remotingClient.ts
@@ -29,6 +29,7 @@ module Shumway.Remoting.Client {
 
   export class ChannelSerializer {
     public output: IDataOutput;
+    public outputAssets: Array<IDataOutput>;
 
     public writeReferences: boolean = false;
     public clearDirtyBits: boolean = false;
@@ -49,9 +50,11 @@ module Shumway.Remoting.Client {
       this.output.writeInt(MessageTag.UpdateFrame);
       this.output.writeInt(graphics._id);
       this.output.writeInt(0); // Not a container.
-      var hasBits = UpdateFrameTagBits.HasBounds;
+      var hasBits = UpdateFrameTagBits.HasBounds | UpdateFrameTagBits.HasShapeData;
       this.output.writeInt(hasBits);
       this.writeRectangle(graphics._getContentBounds());
+      this.output.writeInt(this.outputAssets.length);
+      this.outputAssets.push(graphics._graphicsData);
     }
 
     writeDisplayObject(displayObject: DisplayObject) {

--- a/src/player/remotingServer.ts
+++ b/src/player/remotingServer.ts
@@ -37,6 +37,7 @@ module Shumway.Remoting.Server {
 
   export class ChannelDeserializer {
     input: IDataInput;
+    inputAssets: Array<IDataInput>;
     context: ChannelDeserializerContext;
 
     public read() {
@@ -113,8 +114,18 @@ module Shumway.Remoting.Server {
       if (hasBits & UpdateFrameTagBits.HasMatrix) {
         frame.matrix = this._readMatrix();
       }
+      var bounds: Rectangle;
       if (hasBits & UpdateFrameTagBits.HasBounds) {
-        var bounds = this._readRectangle();
+        bounds = this._readRectangle();
+      }
+      if (hasBits & UpdateFrameTagBits.HasShapeData) {
+        assert(!isContainer);
+        var assetId = input.readInt();
+        var shapeData = this.inputAssets[assetId];
+        this.inputAssets[assetId] = null;
+        var shape = (<Shape>frame);
+        shape.ensureSource(shapeData, bounds);
+      } else if (bounds) {
         var shape = (<Shape>frame);
         if (!shape.source) {
           var renderable = new Renderable(bounds, function (context) {


### PR DESCRIPTION
@yurydelendik, this should at least give you something to work with as far as the shape data is concerned. It doesn't yet do anything with the passed data - I'll flesh that out next.

One thing I realized is that it's hard to impossible to implement an efficient implementation of a shape renderer without having `IDataOutput` available in GFX code. For now, I just added a reference to `bytearray.ts`, but since we don't want GFX to depend on AVM2, we'll have to figure out something else. Perhaps just duplicating the interface is ok.
