### PR TITLE
Work around TS compiler error about import and var name collisions

### DIFF
--- a/src/flash.ts/display/DisplayObjectContainer.ts
+++ b/src/flash.ts/display/DisplayObjectContainer.ts
@@ -22,7 +22,7 @@ module Shumway.AVM2.AS.flash.display {
 
   import VisitorFlags = flash.display.VisitorFlags;
 
-  var Event: typeof flash.events.Event;
+  import events = flash.events;
 
   export class DisplayObjectContainer extends flash.display.InteractiveObject {
     static bindings: string [] = null;
@@ -30,8 +30,6 @@ module Shumway.AVM2.AS.flash.display {
     private static _instances: DisplayObjectContainer [];
 
     static classInitializer: any = function () {
-      Event = flash.events.Event;
-
       DisplayObjectContainer._instances = [];
     };
 
@@ -94,9 +92,9 @@ module Shumway.AVM2.AS.flash.display {
         //  instance._dispatchEvent("load");
         //}
 
-        child.dispatchEvent(Event.getInstance(Event.ADDED, true));
+        child.dispatchEvent(events.Event.getInstance(events.Event.ADDED, true));
         if (this.stage) {
-          child.dispatchEvent(Event.getInstance(Event.ADDED_TO_STAGE));
+          child.dispatchEvent(events.Event.getInstance(events.Event.ADDED_TO_STAGE));
         }
       }
     }
@@ -120,7 +118,7 @@ module Shumway.AVM2.AS.flash.display {
       var old = this._tabChildren;
       this._tabChildren = enable;
       if (old !== enable) {
-        this.dispatchEvent(Event.getInstance(Event.TAB_CHILDREN_CHANGE, true));
+        this.dispatchEvent(events.Event.getInstance(events.Event.TAB_CHILDREN_CHANGE, true));
       }
     }
 
@@ -168,11 +166,11 @@ module Shumway.AVM2.AS.flash.display {
       child._index = index;
       child._parent = this;
       child._invalidatePosition();
-      child.dispatchEvent(Event.getInstance(Event.ADDED, true));
+      child.dispatchEvent(events.Event.getInstance(events.Event.ADDED, true));
       // ADDED event handlers may remove the child from the stage, in such cases
       // we should not dispatch the ADDED_TO_STAGE event.
       if (child.stage) {
-        child._propagateEvent(Event.getInstance(Event.ADDED_TO_STAGE));
+        child._propagateEvent(events.Event.getInstance(events.Event.ADDED_TO_STAGE));
       }
       this._invalidateChildren();
       return child;
@@ -223,9 +221,9 @@ module Shumway.AVM2.AS.flash.display {
 
       var child = children[index];
       if (child._hasFlags(DisplayObjectFlags.Constructed)) {
-        child.dispatchEvent(Event.getInstance(Event.REMOVED, true));
+        child.dispatchEvent(events.Event.getInstance(events.Event.REMOVED, true));
         if (this.stage) {
-          child._propagateEvent(Event.getInstance(Event.REMOVED_FROM_STAGE));
+          child._propagateEvent(events.Event.getInstance(events.Event.REMOVED_FROM_STAGE));
         }
         // Children list might have been mutated by the REMOVED or REMOVED_FROM_STAGE event,
         // we may need to operate on the new index of the child.

--- a/src/flash.ts/display/Graphics.ts
+++ b/src/flash.ts/display/Graphics.ts
@@ -28,19 +28,13 @@ module Shumway.AVM2.AS.flash.display {
   import LineScaleMode = flash.display.LineScaleMode;
   import CapsStyle = flash.display.CapsStyle;
   import JointStyle = flash.display.JointStyle;
-
-  var ByteArray: typeof flash.utils.ByteArray;
-  var Rectangle: typeof flash.geom.Rectangle;
-  var Point: typeof flash.geom.Point;
+  import geom = flash.geom;
+  import utils = flash.utils;
 
   export class Graphics extends ASNative {
     
     // Called whenever the class is initialized.
-    static classInitializer: any = function () {
-      ByteArray = flash.utils.ByteArray;
-      Rectangle = flash.geom.Rectangle;
-      Point = flash.geom.Point; assert (Point);
-    };
+    static classInitializer: any = null;
     
     // Called whenever an instance of the class is initialized.
     static initializer: any = null;
@@ -64,9 +58,9 @@ module Shumway.AVM2.AS.flash.display {
     constructor () {
       false && super();
       this._id = DisplayObject._syncID++;
-      this._graphicsData = new ByteArray();
-      this._rect = new flash.geom.Rectangle();
-      this._bounds = new flash.geom.Rectangle();
+      this._graphicsData = new utils.ByteArray();
+      this._rect = new geom.Rectangle();
+      this._bounds = new geom.Rectangle();
       this._parent = null;
     }
     
@@ -75,17 +69,17 @@ module Shumway.AVM2.AS.flash.display {
     
     // AS -> JS Bindings
 
-    _graphicsData: flash.utils.ByteArray;
+    _graphicsData: utils.ByteArray;
 
     /**
      * Bounding box excluding strokes.
      */
-    _rect: flash.geom.Rectangle;
+    _rect: geom.Rectangle;
 
     /**
      * Bounding box including strokes.
      */
-    _bounds: flash.geom.Rectangle;
+    _bounds: geom.Rectangle;
 
     /**
      * Back reference to the display object that references this graphics object. This is
@@ -104,14 +98,14 @@ module Shumway.AVM2.AS.flash.display {
       this._parent._invalidateBounds();
     }
 
-    _getContentBounds(includeStrokes: boolean = true): flash.geom.Rectangle {
+    _getContentBounds(includeStrokes: boolean = true): geom.Rectangle {
       if (includeStrokes) {
         return this._bounds;
       } else {
         return this._rect;
       }
       notImplemented("public flash.display.Graphics::_getContentBounds");
-      return new flash.geom.Rectangle();
+      return new geom.Rectangle();
     }
 
     clear(): void {
@@ -212,7 +206,8 @@ module Shumway.AVM2.AS.flash.display {
       this.lineTo(x, y + height);
       this.lineTo(x, y);
 
-      this._rect = this._bounds = new Rectangle(x * 20 | 0, y * 20 | 0, width * 20 | 0, height * 20 | 0);
+      this._rect = this._bounds = new geom.Rectangle(x * 20 | 0, y * 20 | 0,
+                                                     width * 20 | 0, height * 20 | 0);
       this._invalidateParent();
     }
 

--- a/src/flash.ts/display/Loader.ts
+++ b/src/flash.ts/display/Loader.ts
@@ -30,13 +30,7 @@ module Shumway.AVM2.AS.flash.display {
   import ActionScriptVersion = flash.display.ActionScriptVersion;
   import BlendMode = flash.display.BlendMode;
 
-  var Event: typeof flash.events.Event;
-  var ProgressEvent: typeof flash.events.ProgressEvent;
-  var IOErrorEvent: typeof flash.events.IOErrorEvent;
-  var LoaderInfo: typeof flash.display.LoaderInfo;
-  var MovieClip: typeof flash.display.MovieClip;
-  var Bitmap: typeof flash.display.Bitmap;
-  var BitmapData: typeof flash.display.BitmapData;
+  import events = flash.events;
 
   enum LoadStatus {
     Unloaded    = 0,
@@ -63,14 +57,6 @@ module Shumway.AVM2.AS.flash.display {
 
     // Called whenever the class is initialized.
     static classInitializer: any = function () {
-      Event = flash.events.Event;
-      ProgressEvent = flash.events.ProgressEvent;
-      IOErrorEvent = flash.events.IOErrorEvent;
-      LoaderInfo = flash.display.LoaderInfo;
-      MovieClip = flash.display.MovieClip;
-      Bitmap = flash.display.Bitmap;
-      BitmapData = flash.display.BitmapData;
-
       Loader._rootLoader = null;
       Loader._loadQueue = [];
     };
@@ -99,10 +85,9 @@ module Shumway.AVM2.AS.flash.display {
         switch (instance._loadStatus) {
           case LoadStatus.Unloaded:
             if (bytesTotal) {
-              loaderInfo.dispatchEvent(Event.getInstance(Event.OPEN));
-              loaderInfo.dispatchEvent(
-                new ProgressEvent(ProgressEvent.PROGRESS, false, false, 0, bytesTotal)
-              );
+              loaderInfo.dispatchEvent(events.Event.getInstance(Event.OPEN));
+              loaderInfo.dispatchEvent(new events.ProgressEvent(events.ProgressEvent.PROGRESS,
+                                                                false, false, 0, bytesTotal));
               if (instance._content) {
                 instance.addChildAtDepth(instance._content, 0);
               }
@@ -113,17 +98,17 @@ module Shumway.AVM2.AS.flash.display {
           case LoadStatus.Opened:
             if (instance._content && instance._content._hasFlags(DisplayObjectFlags.Constructed)) {
               instance._loadStatus = LoadStatus.Initialized;
-              loaderInfo.dispatchEvent(Event.getInstance(Event.INIT));
+              loaderInfo.dispatchEvent(events.Event.getInstance(events.Event.INIT));
             } else {
               break;
             }
           case LoadStatus.Initialized:
             if (bytesLoaded === bytesTotal) {
               instance._loadStatus = LoadStatus.Complete;
-              loaderInfo.dispatchEvent(
-                new ProgressEvent(ProgressEvent.PROGRESS, false, false, bytesLoaded, bytesTotal)
-              );
-              loaderInfo.dispatchEvent(Event.getInstance(Event.COMPLETE));
+              loaderInfo.dispatchEvent(new events.ProgressEvent(events.ProgressEvent.PROGRESS,
+                                                                false, false, bytesLoaded,
+                                                                bytesTotal));
+              loaderInfo.dispatchEvent(events.Event.getInstance(events.Event.COMPLETE));
               queue.shift();
               i--;
             }
@@ -207,9 +192,8 @@ module Shumway.AVM2.AS.flash.display {
             assert (loaderInfo._bytesTotal === bytesTotal, "Total bytes should not change.");
           }
           if (this._loadStatus !== LoadStatus.Unloaded) {
-            loaderInfo.dispatchEvent(
-              new ProgressEvent(ProgressEvent.PROGRESS, false, false, bytesLoaded, bytesTotal)
-            );
+            loaderInfo.dispatchEvent(new events.ProgressEvent(events.ProgressEvent.PROGRESS, false,
+                                                              false, bytesLoaded, bytesTotal));
           }
           break;
         case 'complete':
@@ -223,7 +207,8 @@ module Shumway.AVM2.AS.flash.display {
         //  this._lastPromise = Promise.resolve();
         //  break;
         case 'error':
-          this._contentLoaderInfo.dispatchEvent(new IOErrorEvent(IOErrorEvent.IO_ERROR));
+          this._contentLoaderInfo.dispatchEvent(new events.IOErrorEvent(
+                                                    events.IOErrorEvent.IO_ERROR));
           break;
         default:
           //TODO: fix special-casing. Might have to move document class out of dictionary[0]
@@ -483,7 +468,7 @@ module Shumway.AVM2.AS.flash.display {
       this._worker = null;
       this._lastPromise = this._startPromise;
       this._loadStatus = LoadStatus.Unloaded;
-      this.dispatchEvent(Event.getInstance(Event.UNLOAD));
+      this.dispatchEvent(events.Event.getInstance(events.Event.UNLOAD));
     }
 
     _getJPEGLoaderContextdeblockingfilter(context: flash.system.LoaderContext): number {
@@ -493,10 +478,10 @@ module Shumway.AVM2.AS.flash.display {
       return 0.0;
     }
 
-    _getUncaughtErrorEvents(): flash.events.UncaughtErrorEvents {
+    _getUncaughtErrorEvents(): events.UncaughtErrorEvents {
       notImplemented("public flash.display.Loader::_getUncaughtErrorEvents"); return;
     }
-    _setUncaughtErrorEvents(value: flash.events.UncaughtErrorEvents): void {
+    _setUncaughtErrorEvents(value: events.UncaughtErrorEvents): void {
       value = value;
       notImplemented("public flash.display.Loader::_setUncaughtErrorEvents"); return;
     }

--- a/src/flash.ts/display/MovieClip.ts
+++ b/src/flash.ts/display/MovieClip.ts
@@ -20,10 +20,7 @@ module Shumway.AVM2.AS.flash.display {
   import throwError = Shumway.AVM2.Runtime.throwError;
   import clamp = Shumway.NumberUtilities.clamp;
   import Telemetry = Shumway.Telemetry;
-
-  var Scene: typeof flash.display.Scene;
-  var FrameLabel: typeof flash.display.FrameLabel;
-  var Event: typeof flash.events.Event;
+  import events = flash.events;
 
   export class MovieClip extends flash.display.Sprite {
 
@@ -32,10 +29,6 @@ module Shumway.AVM2.AS.flash.display {
 
     // Called whenever the class is initialized.
     static classInitializer: any = function () {
-      Scene = flash.display.Scene;
-      FrameLabel = flash.display.FrameLabel;
-      Event = flash.events.Event;
-
       MovieClip._instances = [];
       MovieClip._callQueue = [];
     };
@@ -91,12 +84,12 @@ module Shumway.AVM2.AS.flash.display {
           instance._advanceFrame();
         }
       }
-      DisplayObject._broadcastFrameEvent(Event.ENTER_FRAME);
+      DisplayObject._broadcastFrameEvent(events.Event.ENTER_FRAME);
     }
 
     static constructFrame() {
       DisplayObjectContainer.constructChildren();
-      DisplayObject._broadcastFrameEvent(Event.FRAME_CONSTRUCTED);
+      DisplayObject._broadcastFrameEvent(events.Event.FRAME_CONSTRUCTED);
       var queue = MovieClip._callQueue;
       while (queue.length) {
         var instance = queue.shift();
@@ -108,7 +101,7 @@ module Shumway.AVM2.AS.flash.display {
           instance._constructChildren();
         }
       }
-      DisplayObject._broadcastFrameEvent(Event.EXIT_FRAME);
+      DisplayObject._broadcastFrameEvent(events.Event.EXIT_FRAME);
     }
 
     constructor () {

--- a/src/flash.ts/display/SimpleButton.ts
+++ b/src/flash.ts/display/SimpleButton.ts
@@ -18,14 +18,10 @@ module Shumway.AVM2.AS.flash.display {
   import notImplemented = Shumway.Debug.notImplemented;
   import asCoerceString = Shumway.AVM2.Runtime.asCoerceString;
 
-  var DisplayObject: typeof flash.display.DisplayObject;
-
   export class SimpleButton extends flash.display.InteractiveObject {
 
     // Called whenever the class is initialized.
-    static classInitializer: any = function () {
-      DisplayObject = flash.display.DisplayObject;
-    };
+    static classInitializer: any = null;
 
     // Called whenever an instance of the class is initialized.
     static initializer: any = function (symbol: Shumway.Timeline.ButtonSymbol) {

--- a/src/flash.ts/display/Sprite.ts
+++ b/src/flash.ts/display/Sprite.ts
@@ -20,16 +20,10 @@ module Shumway.AVM2.AS.flash.display {
 
   import Timeline = Shumway.Timeline;
 
-  var DisplayObject: typeof flash.display.DisplayObject;
-  var DisplayObjectContainer: typeof flash.display.DisplayObjectContainer;
-
   export class Sprite extends flash.display.DisplayObjectContainer {
 
     // Called whenever the class is initialized.
-    static classInitializer: any = function () {
-      DisplayObject = flash.display.DisplayObject;
-      DisplayObjectContainer = flash.display.DisplayObjectContainer;
-    };
+    static classInitializer: any = null;
     
     // Called whenever an instance of the class is initialized.
     static initializer: any = function (symbol: Timeline.SpriteSymbol) {

--- a/src/flash.ts/display/Stage.ts
+++ b/src/flash.ts/display/Stage.ts
@@ -23,16 +23,11 @@ module Shumway.AVM2.AS.flash.display {
   import ColorCorrection = flash.display.ColorCorrection;
   import ColorCorrectionSupport = flash.display.ColorCorrectionSupport;
   import StageQuality = flash.display.StageQuality;
-
-  var DisplayObject: typeof flash.display.DisplayObject;
-  var Event: typeof flash.events.Event;
+  import Event = flash.events.Event;
 
   export class Stage extends flash.display.DisplayObjectContainer {
 
-    static classInitializer: any = function () {
-      DisplayObject = flash.display.DisplayObject;
-      Event = flash.events.Event;
-    };
+    static classInitializer: any = null;
 
     static classSymbols: string [] = null; // [];
     static instanceSymbols: string [] = null; // ["name", "mask", "visible", "x", "y", "z", "scaleX", "scaleY", "scaleZ", "rotation", "rotationX", "rotationY", "rotationZ", "alpha", "cacheAsBitmap", "opaqueBackground", "scrollRect", "filters", "blendMode", "transform", "accessibilityProperties", "scale9Grid", "tabEnabled", "tabIndex", "focusRect", "mouseEnabled", "accessibilityImplementation", "width", "width", "height", "height", "textSnapshot", "mouseChildren", "mouseChildren", "numChildren", "tabChildren", "tabChildren", "contextMenu", "constructor", "constructor", "addChild", "addChildAt", "setChildIndex", "addEventListener", "hasEventListener", "willTrigger", "dispatchEvent"];


### PR DESCRIPTION
This patch does two things, one of which should be uncontroversial, the other maybe not so much:
- remove redundant imports for classes in the same package
- replace the compiler error TSC spits out for `var Foo: typeof some.nested.package.Foo` by instead using `import package = some.nested.package` and then changing all references to `Foo` to `package.Foo`

@mbebenita, I couldn't come up with a better solution. Also, I fear that we might even run into this far, far more with future versions of TSC: it doesn't really make sense that they compile references to classes in the same package as `package.Foo` automatically. I think it's likely that they'll just automatically import all required classes automatically, and then compile that to `Foo` just as with explicitly imported classes.
