### PR TITLE
Add declaration of Path2D class to 2D GFX backend

### DIFF
--- a/src/gfx/2d/2d.ts
+++ b/src/gfx/2d/2d.ts
@@ -2,6 +2,25 @@
 
 interface CanvasRenderingContext2D {
   stackDepth: number;
+  fill(path: Path2D, fillRule?: string): void;
+  stroke(path: Path2D): void;
+}
+
+declare class Path2D {
+  constructor();
+  constructor(path:Path2D);
+  constructor(paths: Path2D[], fillRule?: string);
+  constructor(d: any);
+
+  addPath(path: Path2D, transform?: SVGMatrix): void;
+  moveTo(x: number, y: number): void;
+  lineTo(x: number, y: number): void;
+  quadraticCurveTo(cpx: number, cpy: number, x: number, y: number): void;
+  bezierCurveTo(cp1x: number, cp1y: number, cp2x: number, cp2y: number, x: number, y: number): void;
+  rect(x: number, y: number, w: number, h: number): void;
+  arc(x: number, y: number, radius: number, startAngle: number, endAngle: number, anticlockwise?: boolean): void;
+  arcTo(x1: number, y1: number, x2: number, y2: number, radius: number): void;
+  closePath(): void;
 }
 
 module Shumway.GFX {


### PR DESCRIPTION
Doesn't yet exist in tsc's lib.d.ts.
