### PR TITLE
Fix reference to GenericVector.ts to have correct casing

### DIFF
--- a/src/avm2/references.ts
+++ b/src/avm2/references.ts
@@ -36,7 +36,7 @@
 ///<reference path='natives/uint32Vector.ts' />
 ///<reference path='natives/float64Vector.ts' />
 ///<reference path='native.ts' />
-///<reference path='natives/genericVector.ts' />
+///<reference path='natives/GenericVector.ts' />
 ///<reference path='natives/xml.ts' />
 ///<reference path='natives/dictionary.ts' />
 ///<reference path='natives/proxy.ts' />


### PR DESCRIPTION
avm2/references.ts referred to `genericVector.ts`, which causes problem on case-sensitive filesystems.
