### PR TITLE
Add ColorUtilities.componentsToRGBA

### DIFF
--- a/src/flash/filters/BevelFilter.ts
+++ b/src/flash/filters/BevelFilter.ts
@@ -36,12 +36,12 @@ module Shumway.AVM2.AS.flash.filters {
 
     public static FromUntyped(obj: any) {
       // obj.highlightColor is an object with separate color components
-      var highlightColor: number = ColorUtilities.componentsToRgb(obj.highlightColor);
+      var highlightColor: number = ColorUtilities.componentsToRGB(obj.highlightColor);
       var highlightAlpha: number = (obj.highlightColor.alpha & 0xff) / 255;
       // obj.colors is an array of objects with separate color components
       // here it contains exactly one color object, which maps to shadowColor and shadowAlpha
       assert(obj.colors && obj.colors.length === 1, "colors must be Array of length 1");
-      var shadowColor: number = ColorUtilities.componentsToRgb(obj.colors[0]);
+      var shadowColor: number = ColorUtilities.componentsToRGB(obj.colors[0]);
       var shadowAlpha: number = (obj.colors[0].alpha & 0xff) / 255;
       // type is derived from obj.onTop and obj.innerShadow
       // obj.onTop true: type is FULL

--- a/src/flash/filters/ConvolutionFilter.ts
+++ b/src/flash/filters/ConvolutionFilter.ts
@@ -32,7 +32,7 @@ module Shumway.AVM2.AS.flash.filters {
 
     public static FromUntyped(obj: any) {
       // obj.color is an object with separate color components
-      var color: number = ColorUtilities.componentsToRgb(obj.color);
+      var color: number = ColorUtilities.componentsToRGB(obj.color);
       var alpha: number = (obj.color.alpha & 0xff) / 255;
       return new ConvolutionFilter(
         obj.matrixX,

--- a/src/flash/filters/DropShadowFilter.ts
+++ b/src/flash/filters/DropShadowFilter.ts
@@ -37,7 +37,7 @@ module Shumway.AVM2.AS.flash.filters {
       // obj.colors is an array of objects with separate color components
       // here it contains exactly one color object, which maps to color and alpha
       assert(obj.colors && obj.colors.length === 1, "colors must be Array of length 1");
-      var color: number = ColorUtilities.componentsToRgb(obj.colors[0]);
+      var color: number = ColorUtilities.componentsToRGB(obj.colors[0]);
       var alpha: number = (obj.colors[0].alpha & 0xff) / 255;
       // obj.angle is represented in radians, the api needs degrees
       var angle: number = obj.angle * 180 / Math.PI;

--- a/src/flash/filters/GlowFilter.ts
+++ b/src/flash/filters/GlowFilter.ts
@@ -37,7 +37,7 @@ module Shumway.AVM2.AS.flash.filters {
       // obj.colors is an array of objects with separate color components
       // here it contains exactly one color object, which maps to color and alpha
       assert(obj.colors && obj.colors.length === 1, "colors must be Array of length 1");
-      var color: number = ColorUtilities.componentsToRgb(obj.colors[0]);
+      var color: number = ColorUtilities.componentsToRGB(obj.colors[0]);
       var alpha: number = (obj.colors[0].alpha & 0xff) / 255;
       return new GlowFilter(
         color,

--- a/src/flash/filters/GradientBevelFilter.ts
+++ b/src/flash/filters/GradientBevelFilter.ts
@@ -37,7 +37,7 @@ module Shumway.AVM2.AS.flash.filters {
       // obj.colors is an array of objects with separate color components
       // the rgb and alpha components must be separated into colors and alphas arrays
       var colors = obj.colors.map(function(value) {
-        return ColorUtilities.componentsToRgb(value);
+        return ColorUtilities.componentsToRGB(value);
       });
       var alphas = obj.colors.map(function(value) {
         return (value.alpha & 0xff) / 255;

--- a/src/flash/filters/GradientGlowFilter.ts
+++ b/src/flash/filters/GradientGlowFilter.ts
@@ -37,7 +37,7 @@ module Shumway.AVM2.AS.flash.filters {
       // obj.colors is an array of objects with separate color components
       // the rgb and alpha components must be separated into colors and alphas arrays
       var colors = obj.colors.map(function(value) {
-        return ColorUtilities.componentsToRgb(value);
+        return ColorUtilities.componentsToRGB(value);
       });
       var alphas = obj.colors.map(function(value) {
         return (value.alpha & 0xff) / 255;

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -2638,7 +2638,7 @@ module Shumway {
   export interface RGBAComponents {red: number; green: number; blue: number; alpha: number}
 
   export module ColorUtilities {
-    export function componentsToRgb(components: RGBComponents): number {
+    export function componentsToRGB(components: RGBComponents): number {
       return ((components.red << 16) | (components.green << 8) | components.blue) >>> 0;
     }
 


### PR DESCRIPTION
, introduce interfaces for RGBComponents and RGBAComponents, and rename ColorUtilities.componentsToRgb to ColorUtilities.componentsToRGB for consistency.
