### PR TITLE
Turn internal DisplayObject methods for handling text and graphics content into overridable base versions

### DIFF
--- a/src/flash/display/DisplayObject.ts
+++ b/src/flash/display/DisplayObject.ts
@@ -1337,37 +1337,20 @@ module Shumway.AVM2.AS.flash.display {
      * Only these objects can have graphics.
      */
     _canHaveGraphics(): boolean {
-      return flash.display.Shape.isType(this) ||
-             flash.display.Sprite.isType(this) ||
-             flash.display.MorphShape.isType(this);
+      return false;
     }
 
     /**
-     * Only these objects can have text content.
-     */
-    _canHaveTextContent(): boolean {
-      return flash.text.StaticText.isType(this) || flash.text.TextField.isType(this);
-    }
-
-    /**
-     * Gets the graphics object of this object. Only Shapes, Sprites, and MorphShapes can have
-     * graphics.
+     * Gets the graphics object of this object. Shapes, MorphShapes, and Sprites override this.
      */
     _getGraphics(): flash.display.Graphics {
-      if (this._canHaveGraphics()) {
-        return (<any>this)._graphics;
-      }
       return null;
     }
 
     /**
-     * Gets the text content of this object. Only StaticTexts and TextFields can have
-     * text content.
+     * Gets the text content of this object. StaticTexts and TextFields override this.
      */
     _getTextContent(): Shumway.TextContent {
-      if (this._canHaveTextContent()) {
-        return (<any>this)._textContent;
-      }
       return null;
     }
 
@@ -1387,18 +1370,15 @@ module Shumway.AVM2.AS.flash.display {
     }
 
     /**
-     * This is only ever called from |_animate|. Thes graphics objects cannot be modified so they don't need a back reference.
+     * This is only ever called from |_animate|. These graphics objects cannot be modified so
+     * they don't need a back reference.
      */
     _setGraphics(graphics: flash.display.Graphics) {
-      if (this._canHaveGraphics()) {
-        this._graphics = graphics;
-        this._invalidateFillAndLineBounds();
-        this._setDirtyFlags(DisplayObjectFlags.DirtyGraphics);
-        return;
-      }
-      unexpected("Cannot set graphics on this type of display object.");
+      assert(this._canHaveGraphics(), "Cannot set graphics on this type of display object.");
+      this._graphics = graphics;
+      this._invalidateFillAndLineBounds();
+      this._setDirtyFlags(DisplayObjectFlags.DirtyGraphics);
     }
-
     /**
      * Checks if the bounding boxes of two display objects overlap, this happens in the global
      * coordinate coordinate space.

--- a/src/flash/display/MorphShape.ts
+++ b/src/flash/display/MorphShape.ts
@@ -54,5 +54,17 @@ module Shumway.AVM2.AS.flash.display {
     _graphics: flash.display.Graphics;
     morphFillBounds: Bounds;
     morphLineBounds: Bounds;
+
+    _canHaveGraphics(): boolean {
+      return true;
+    }
+
+    _getGraphics(): flash.display.Graphics {
+      return this._graphics;
+    }
+
+    get graphics(): flash.display.Graphics {
+      return this._ensureGraphics();
+    }
   }
 }

--- a/src/flash/display/Shape.ts
+++ b/src/flash/display/Shape.ts
@@ -38,6 +38,14 @@ module Shumway.AVM2.AS.flash.display {
       DisplayObject.instanceConstructorNoInitialize.call(this);
     }
 
+    _canHaveGraphics(): boolean {
+      return true;
+    }
+
+    _getGraphics(): flash.display.Graphics {
+      return this._graphics;
+    }
+
     get graphics(): flash.display.Graphics {
       return this._ensureGraphics();
     }

--- a/src/flash/display/Sprite.ts
+++ b/src/flash/display/Sprite.ts
@@ -82,6 +82,14 @@ module Shumway.AVM2.AS.flash.display {
       }
     }
 
+    _canHaveGraphics(): boolean {
+      return true;
+    }
+
+    _getGraphics(): flash.display.Graphics {
+      return this._graphics;
+    }
+
     get graphics(): flash.display.Graphics {
       return this._ensureGraphics();
     }

--- a/src/flash/text/StaticText.ts
+++ b/src/flash/text/StaticText.ts
@@ -39,6 +39,10 @@ module Shumway.AVM2.AS.flash.text {
       flash.display.DisplayObject.instanceConstructorNoInitialize.call(this);
     }
 
+    _getTextContent(): Shumway.TextContent {
+      return this._textContent;
+    }
+
     private _text: string;
 
     _textContent: Shumway.TextContent;

--- a/src/flash/text/TextField.ts
+++ b/src/flash/text/TextField.ts
@@ -121,6 +121,12 @@ module Shumway.AVM2.AS.flash.text {
       notImplemented("Dummy Constructor: public flash.text.TextField");
     }
 
+    _getTextContent(): Shumway.TextContent {
+      return this._textContent;
+    }
+
+    _textContent: Shumway.TextContent;
+
     // JS -> AS Bindings
 
     //selectedText: string;
@@ -177,8 +183,6 @@ module Shumway.AVM2.AS.flash.text {
     _type: string;
     _wordWrap: boolean;
     _useRichTextClipboard: boolean;
-
-    _textContent: Shumway.TextContent;
 
     get alwaysShowSelection(): boolean {
       return this._alwaysShowSelection;


### PR DESCRIPTION
This way, the normal path isn't slowed down/complicated by special casing for the various displayable things.
