### PR TITLE
Include new TextField dependencies in player.package

### DIFF
--- a/examples/inspector/inspector.html
+++ b/examples/inspector/inspector.html
@@ -277,6 +277,9 @@ limitations under the License.
 
     <!-- Load Flash TS Dependencies -->
     <script> Shumway.Player.enterTimeline("Load Flash TS Dependencies"); </script>
+
+    <script src="../../build/ts/TextContent.js"></script>
+
     <script src="../../build/ts/flash/geom/Matrix.js"></script>
     <script src="../../build/ts/flash/geom/PerspectiveProjection.js"></script>
     <script src="../../build/ts/flash/geom/ColorTransform.js"></script>
@@ -673,8 +676,6 @@ limitations under the License.
     <script src="../../build/ts/player/avmLoader.js"></script>
 
     <script src="../../build/ts/flash/linker.js"></script>
-
-    <script src="../../build/ts/TextContent.js"></script>
 
     <script> console.timeEnd("Load Player Dependencies"); </script>
 

--- a/examples/inspector/inspector.player.html
+++ b/examples/inspector/inspector.player.html
@@ -146,6 +146,9 @@ limitations under the License.
 
     <!-- Load Flash TS Dependencies -->
     <script> Shumway.Player.enterTimeline("Load Flash TS Dependencies"); </script>
+
+    <script src="../../build/ts/TextContent.js"></script>
+
     <script src="../../build/ts/flash/geom/Matrix.js"></script>
     <script src="../../build/ts/flash/geom/PerspectiveProjection.js"></script>
     <script src="../../build/ts/flash/geom/ColorTransform.js"></script>
@@ -362,7 +365,7 @@ limitations under the License.
     <!--<script src="../../build/ts/flash/text/CSMSettings.js"></script>-->
     <!--<script src="../../build/ts/flash/events/StageVideoAvailabilityEvent.js"></script>-->
     <!--<script src="../../build/ts/flash/net/NetGroupSendMode.js"></script>-->
-    <!--<script src="../../build/ts/flash/text/TextRun.js"></script>-->
+    <script src="../../build/ts/flash/text/TextRun.js"></script>
     <!--<script src="../../build/ts/flash/net/XMLSocket.js"></script>-->
     <!--<script src="../../build/ts/flash/utils/Dictionary.js"></script>-->
     <!--<script src="../../build/ts/flash/display3D/Context3DCompareMode.js"></script>-->

--- a/examples/shell/run.js
+++ b/examples/shell/run.js
@@ -139,6 +139,9 @@ load("../../build/ts/player/module.js");
 
 // Load Flash TS Dependencies
 Shumway.Player.enterTimeline("Load Flash TS Dependencies");
+
+load("../../build/ts/TextContent.js");
+
 load("../../build/ts/flash/geom/Matrix.js");
 load("../../build/ts/flash/geom/PerspectiveProjection.js");
 load("../../build/ts/flash/geom/ColorTransform.js");
@@ -355,7 +358,7 @@ load("../../build/ts/flash/accessibility/AccessibilityImplementation.js");
 //../../build/ts/flash/text/CSMSettings.js
 //../../build/ts/flash/events/StageVideoAvailabilityEvent.js
 //../../build/ts/flash/net/NetGroupSendMode.js
-//../../build/ts/flash/text/TextRun.js
+load("../../build/ts/flash/text/TextRun.js");
 //../../build/ts/flash/net/XMLSocket.js
 //../../build/ts/flash/utils/Dictionary.js
 //../../build/ts/flash/display3D/Context3DCompareMode.js

--- a/examples/xlsimport/index.html
+++ b/examples/xlsimport/index.html
@@ -200,6 +200,9 @@ limitations under the License.
 
     <!-- Load Flash TS Dependencies -->
     <script> Shumway.Player.enterTimeline("Load Flash TS Dependencies"); </script>
+
+    <script src="../../build/ts/TextContent.js"></script>
+
     <script src="../../build/ts/flash/geom/Matrix.js"></script>
     <script src="../../build/ts/flash/geom/PerspectiveProjection.js"></script>
     <script src="../../build/ts/flash/geom/ColorTransform.js"></script>
@@ -596,8 +599,6 @@ limitations under the License.
     <script src="../../build/ts/player/avmLoader.js"></script>
 
     <script src="../../build/ts/flash/linker.js"></script>
-
-    <script src="../../build/ts/TextContent.js"></script>
 
     <script> console.timeEnd("Load Player Dependencies"); </script>
 

--- a/src/shumway.player.package
+++ b/src/shumway.player.package
@@ -74,6 +74,9 @@ build/ts/player/module.js
 
 ## Load Flash TS Dependencies
 #!inline Shumway.Player.enterTimeline("Load Flash TS Dependencies");
+
+build/ts/TextContent.js
+
 build/ts/flash/geom/Matrix.js
 build/ts/flash/geom/PerspectiveProjection.js
 build/ts/flash/geom/ColorTransform.js
@@ -290,7 +293,7 @@ build/ts/flash/accessibility/AccessibilityImplementation.js
 #build/ts/flash/text/CSMSettings.js
 #build/ts/flash/events/StageVideoAvailabilityEvent.js
 #build/ts/flash/net/NetGroupSendMode.js
-#build/ts/flash/text/TextRun.js
+build/ts/flash/text/TextRun.js
 #build/ts/flash/net/XMLSocket.js
 #build/ts/flash/utils/Dictionary.js
 #build/ts/flash/display3D/Context3DCompareMode.js

--- a/test/harness/slave.html
+++ b/test/harness/slave.html
@@ -198,6 +198,9 @@ limitations under the License.
 
     <!-- Load Flash TS Dependencies -->
     <script> Shumway.Player.enterTimeline("Load Flash TS Dependencies"); </script>
+
+    <script src="../../build/ts/TextContent.js"></script>
+
     <script src="../../build/ts/flash/geom/Matrix.js"></script>
     <script src="../../build/ts/flash/geom/PerspectiveProjection.js"></script>
     <script src="../../build/ts/flash/geom/ColorTransform.js"></script>
@@ -594,8 +597,6 @@ limitations under the License.
     <script src="../../build/ts/player/avmLoader.js"></script>
 
     <script src="../../build/ts/flash/linker.js"></script>
-
-    <script src="../../build/ts/TextContent.js"></script>
 
     <script> console.timeEnd("Load Player Dependencies"); </script>
 


### PR DESCRIPTION
... instead of them only being added to some embeddings manually.

@tobytailor, adding dependencies to the `.package` files and then calling `grunt update-refs` is critically important. Not only will you forget embeddings otherwise, your changes will also be overwritten the next time someone uses `update-refs`.
