### PR TITLE
Fix native binding of AS2Utils class

### DIFF
--- a/src/flash/avm1.d.ts
+++ b/src/flash/avm1.d.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
+import ASClass = Shumway.AVM2.AS.ASClass;
 declare module Shumway.AVM2.AS.avm1lib {
-  import ASClass = Shumway.AVM2.AS.ASClass;
   export class AS2Globals extends ASClass {}
   export class AS2Utils extends ASClass {}
   export class AS2MovieClip extends ASClass {}
@@ -37,4 +37,5 @@ declare module Shumway.AVM1 {
 
     globals: Shumway.AVM2.AS.avm1lib.AS2Globals;
   }
+  export class AS2Utils extends ASClass {}
 }

--- a/src/flash/linker.ts
+++ b/src/flash/linker.ts
@@ -178,7 +178,7 @@ module Shumway.AVM2.AS {
       M("flash.utils.Timer", "TimerClass", flash.utils.Timer),
       M("flash.utils.ByteArray", "ByteArrayClass", flash.utils.ByteArray),
 
-      M("avm1lib.AS2Utils", "AS2Utils", Shumway.AVM2.AS.avm1lib.AS2Utils),
+      M("avm1lib.AS2Utils", "AS2Utils", Shumway.AVM1.AS2Utils),
       M("avm1lib.AS2Broadcaster"),
       M("avm1lib.AS2Key"),
       M("avm1lib.AS2Mouse"),


### PR DESCRIPTION
I regressed this while untangling the `avm1`, `avm1lib` and `flash` build targets.
