### PR TITLE
Make IAdvancable instances add themselves to DisplayObject._advancableInstances instead of doing it in the DisplayObject initializer

### DIFF
--- a/src/flash/display/DisplayObject.ts
+++ b/src/flash/display/DisplayObject.ts
@@ -258,7 +258,7 @@ module Shumway.AVM2.AS.flash.display {
       return this._syncID++
     }
 
-    private static _advancableInstances: WeakList<IAdvancable>;
+    static _advancableInstances: WeakList<IAdvancable>;
 
     // Called whenever the class is initialized.
     static classInitializer: any = function () {
@@ -272,10 +272,6 @@ module Shumway.AVM2.AS.flash.display {
     // Called whenever an instance of the class is initialized.
     static initializer: any = function (symbol: Shumway.Timeline.DisplaySymbol) {
       var self: DisplayObject = this;
-
-      if ('_initFrame' in self && '_constructFrame' in self) {
-        DisplayObject._advancableInstances.push(<any>self);
-      }
 
       self._id = flash.display.DisplayObject.getNextSyncID();
       self._displayObjectFlags = DisplayObjectFlags.Visible                            |

--- a/src/flash/display/Loader.ts
+++ b/src/flash/display/Loader.ts
@@ -66,7 +66,10 @@ module Shumway.AVM2.AS.flash.display {
     };
 
     // Called whenever an instance of the class is initialized.
-    static initializer: any = null;
+    static initializer: any = function() {
+      var self: Loader = this;
+      DisplayObject._advancableInstances.push(self);
+    };
 
     // List of static symbols to link.
     static classSymbols: string [] = null; // [];

--- a/src/flash/display/MovieClip.ts
+++ b/src/flash/display/MovieClip.ts
@@ -44,6 +44,8 @@ module Shumway.AVM2.AS.flash.display {
     static initializer: any = function (symbol: Shumway.Timeline.SpriteSymbol) {
       var self: MovieClip = this;
 
+      DisplayObject._advancableInstances.push(self);
+
       self._currentFrame = 0;
       self._totalFrames = 1;
       self._trackAsMenu = false;


### PR DESCRIPTION
That way, we don't have to do shape-testing in the base initializer.
