### PR TITLE
Fixes 

### DIFF
--- a/src/swf/parser/font.ts
+++ b/src/swf/parser/font.ts
@@ -46,12 +46,15 @@ module Shumway.SWF.Parser {
     var uniqueName = 'swf-font-' + tag.id;
     var fontName = tag.name || uniqueName;
 
+    var resolution = tag.resolution || 1;
+
     var font = {
       type: 'font',
       id: tag.id,
       name: fontName,
       bold: tag.bold === 1,
       italic: tag.italic === 1,
+      resolution: resolution,
       codes: null,
       metrics: null,
       data: null
@@ -104,7 +107,6 @@ module Shumway.SWF.Parser {
       ranges.push([UAC_OFFSET, UAC_OFFSET + glyphCount - 1, indices]);
     }
 
-    var resolution = tag.resolution || 1;
     var ascent = Math.ceil(tag.ascent / resolution) || 1024;
     var descent = -Math.ceil(tag.descent / resolution) | 0;
     var leading = (tag.leading / resolution) | 0;

--- a/src/swf/parser/label.ts
+++ b/src/swf/parser/label.ts
@@ -44,7 +44,7 @@ module Shumway.SWF.Parser {
         release || assert(font, 'undefined font', 'label');
         codes = font.codes;
         dependencies.push(font.id);
-        size = record.fontHeight > 160 ? record.fontHeight / 20 : record.fontHeight;
+        size = (record.fontHeight > 160 ? record.fontHeight / 20 : record.fontHeight) / font.resolution;
         face = 'swffont' + font.id;
       }
       if (record.hasColor) {


### PR DESCRIPTION
Glyphs coordinates in DefineFont3 tags are defined in twips instead of points. When a DefineText tag refers such a font, we have to convert the font size to points/pixels as well.
