### PR TITLE
Unify the frame events cycle into one main entry point - DisplayObject.performFrameNavigation

### DIFF
--- a/src/flash/display/Loader.ts
+++ b/src/flash/display/Loader.ts
@@ -144,7 +144,7 @@ module Shumway.AVM2.AS.flash.display {
       ]);
     }
 
-    _initFrame() { }
+    _initFrame(advance: boolean) { }
 
     _constructFrame() {
       this._constructChildren();

--- a/src/flash/display/SimpleButton.ts
+++ b/src/flash/display/SimpleButton.ts
@@ -71,8 +71,10 @@ module Shumway.AVM2.AS.flash.display {
       notImplemented("Dummy Constructor: public flash.display.SimpleButton");
     }
 
-    _initFrame() {
-      this._updateButton();
+    _initFrame(advance: boolean) {
+      if (advance) {
+        this._updateButton();
+      }
     }
 
     _constructFrame() { }

--- a/src/player/options.ts
+++ b/src/player/options.ts
@@ -52,14 +52,6 @@ module Shumway {
     new Shumway.Options.Option("", "Play Symbols", "boolean", false, "Plays all SWF symbols automatically.")
   );
 
-  export var initFrameOption = playerOptions.register (
-    new Shumway.Options.Option("", "Init Frame", "boolean", true, "Call MovieClip.initFrame.")
-  );
-
-  export var constructFrameOption = playerOptions.register (
-    new Shumway.Options.Option("", "Construct Frame", "boolean", true, "Call MovieClip.constructFrame.")
-  );
-
   export var playSymbolOption = playerOptions.register (
     new Shumway.Options.Option("", "Play Symbol Number", "number", 0, "Select symbol by Id.", {range: { min: 0, max: 20000, step: 1 }})
   );

--- a/src/player/player.ts
+++ b/src/player/player.ts
@@ -303,24 +303,17 @@ module Shumway.Player {
       var stage = this._stage;
       var rootInitialized = false;
       (function tick() {
+        // TODO: change this to the mode described in http://www.craftymind.com/2008/04/18/updated-elastic-racetrack-for-flash-9-and-avm2/
         self._frameTimeout = setTimeout(tick, 1000 / frameRateOption.value);
-        if (!frameEnabledOption.value || self._shouldThrottleDownFrameExecution()) {
+        if (!frameEnabledOption.value && !playAllSymbolsOption.value ||
+            self._shouldThrottleDownFrameExecution())
+        {
           return;
         }
         stage.scaleX = stage.scaleY = stageScaleOption.value;
         for (var i = 0; i < frameRateMultiplierOption.value; i++) {
           enterTimeline("eventLoop");
-          if (initFrameOption.value) {
-            DisplayObject.initFrame();
-          }
-          if (constructFrameOption.value) {
-            DisplayObject.constructFrame();
-          }
-          if (!playAllSymbolsOption.value) {
-            MovieClip.executeAndExitFrame();
-          } else {
-            MovieClip.reset();
-          }
+          DisplayObject.performFrameNavigation(true, !playAllSymbolsOption.value);
           Loader.progress();
           leaveTimeline("eventLoop");
         }

--- a/test/unit/MovieClip.js
+++ b/test/unit/MovieClip.js
@@ -103,9 +103,8 @@
       framesExecuted[0]++;
     });
     eq(framesExecuted[0], 0, "Just adding a script to the current frame doesn't run it");
-    DisplayObject.constructFrame();
-    MovieClip.executeAndExitFrame();
-    eq(framesExecuted[0], 1, "MovieClip.constructFrame() runs queued scripts");
+    MovieClip.runFrameScripts();
+    eq(framesExecuted[0], 1, "MovieClip.runFrameScripts() runs queued scripts");
     mc.addFrameScript(2, function(){
       framesExecuted[3]++;
     });


### PR DESCRIPTION
And document the various steps involved and why some are skipped in some places.
