### PR TITLE
Propagate MovieClip's frame script pending-info upon being added to the stage

### DIFF
--- a/src/flash/display/DisplayObject.ts
+++ b/src/flash/display/DisplayObject.ts
@@ -481,6 +481,17 @@ module Shumway.AVM2.AS.flash.display {
       this._setFlags(DisplayObjectFlags.Constructed);
     }
 
+    _setParent(parent: DisplayObjectContainer, depth: number) {
+      var oldParent = this._parent;
+      this._parent = parent;
+      this._depth = depth;
+      if (parent) {
+        this._addReference();
+      } else if (oldParent) {
+        this._removeReference();
+      }
+    }
+
     _setFillAndLineBoundsFromWidthAndHeight(width: number, height: number) {
       this._fillBounds.width = width;
       this._fillBounds.height = height;

--- a/src/flash/display/DisplayObjectContainer.ts
+++ b/src/flash/display/DisplayObjectContainer.ts
@@ -180,10 +180,8 @@ module Shumway.AVM2.AS.flash.display {
         children[i]._index++;
       }
       children.splice(index, 0, child);
-      child._depth = -1;
+      child._setParent(this, -1);
       child._index = index;
-      child._parent = this;
-      child._addReference();
       child._invalidatePosition();
       child.dispatchEvent(events.Event.getInstance(events.Event.ADDED, true));
       // ADDED event handlers may remove the child from the stage, in such cases
@@ -227,8 +225,7 @@ module Shumway.AVM2.AS.flash.display {
           children[i]._index = i;
         }
       }
-      child._parent = this;
-      child._depth = depth;
+      child._setParent(this, depth);
       child._invalidatePosition();
       this._invalidateChildren();
     }
@@ -260,9 +257,8 @@ module Shumway.AVM2.AS.flash.display {
       for (var i = children.length - 1; i >= index; i--) {
         children[i]._index--;
       }
-      child._depth = -1;
+      child._setParent(null, -1);
       child._index = -1;
-      child._parent = null;
       child._invalidatePosition();
       this._invalidateChildren();
       return child;

--- a/src/flash/display/MovieClip.ts
+++ b/src/flash/display/MovieClip.ts
@@ -111,6 +111,13 @@ module Shumway.AVM2.AS.flash.display {
       Sprite.instanceConstructorNoInitialize.call(this);
     }
 
+    _setParent(parent: DisplayObjectContainer, depth: number) {
+      super._setParent(parent, depth);
+      if (parent && this._hasFlags(DisplayObjectFlags.HasFrameScriptPending)) {
+        parent._propagateFlagsUp(DisplayObjectFlags.ContainsFrameScriptPendingChildren);
+      }
+    }
+
     _initFrame(advance: boolean) {
       if (advance && this.buttonMode) {
         var state: string = null;


### PR DESCRIPTION
Also abstracts the operation of setting a parent and consistently applies `add/removeReference`.

Fixes the situation where a frame script is added to a MovieClip before it is added to the stage, and then the play head doesn't move, so nobody ever knew about the script.
