### PR TITLE
font resolution default to 1

### DIFF
--- a/src/swf/parser/font.ts
+++ b/src/swf/parser/font.ts
@@ -126,10 +126,6 @@ module Shumway.SWF.Parser {
     }
 
     var resolution = tag.resolution || 1;
-    if (isFont2 && !tag.hasLayout) {
-      // some DefineFont2 without layout using DefineFont3 resolution, why?
-      resolution = 20;
-    }
     var ascent = Math.ceil(tag.ascent / resolution) || 1024;
     var descent = -Math.ceil(tag.descent / resolution) || 0;
     var leading = (tag.leading / resolution) || 0;


### PR DESCRIPTION
since 2e96a14 the label always divides the font size with 20, the resolution can be defaulted to 1. If you have test swfs for text rendering, then please check this PR for regression!
