### PR TITLE
Avoid excess allocations in assert().

### DIFF
--- a/src/avm2/bindings.ts
+++ b/src/avm2/bindings.ts
@@ -409,13 +409,13 @@ module Shumway.AVM2.Runtime {
         var oldBinding = object[key];
         if (oldBinding) {
           var oldTrait = oldBinding.trait;
-          release || assert (!oldTrait.isFinal(), "Cannot redefine a final trait: ", trait);
+          release || assert (!oldTrait.isFinal(), "Cannot redefine a final trait: " + trait);
           // TODO: Object.as has a trait named length, we need to remove this since
           // it doesn't appear in Tamarin.
           release || assert (trait.isOverride() || trait.name.getName() === "length",
-            "Overriding a trait that is not marked for override: ", trait);
+            "Overriding a trait that is not marked for override: " + trait);
         } else {
-          release || assert (!trait.isOverride(), "Trait marked override must override another trait: ", trait);
+          release || assert (!trait.isOverride(), "Trait marked override must override another trait: " + trait);
         }
         object[key] = binding;
       }

--- a/src/avm2/compiler/builder.ts
+++ b/src/avm2/compiler/builder.ts
@@ -187,7 +187,7 @@ module Shumway.AVM2.Compiler {
 
     merge(control: Control, other: State) {
       release || assert (control);
-      release || assert (this.matches(other), this, " !== ", other);
+      release || assert (this.matches(other), this + " !== " + other);
       State.mergeValues(control, this.local, other.local);
       State.mergeValues(control, this.stack, other.stack);
       State.mergeValues(control, this.scope, other.scope);

--- a/src/avm2/compiler/c4/backend.ts
+++ b/src/avm2/compiler/c4/backend.ts
@@ -400,14 +400,14 @@ module Shumway.AVM2.Compiler.Backend {
 
   function compileValue(value, cx: Context, noVariable?) {
     release || assert (value);
-    release || assert (value.compile, "Implement |compile| for ", value, " (", value.nodeName + ")");
+    release || assert (value.compile, "Implement |compile| for " + value + " (" + value.nodeName + ")");
     release || assert (cx instanceof Context);
     release || assert (!isArray(value));
     if (noVariable || !value.variable) {
       var node = value.compile(cx);
       return node;
     }
-    release || assert (value.variable, "Value has no variable: ", value);
+    release || assert (value.variable, "Value has no variable: " + value);
     return id(value.variable.name);
   }
 

--- a/src/avm2/compiler/c4/optimizer.ts
+++ b/src/avm2/compiler/c4/optimizer.ts
@@ -599,7 +599,7 @@ module Shumway.AVM2.Compiler.IR {
     }
 
     computeDominators(apply) {
-      release || assert (this.root.predecessors.length === 0, "Root node ", this.root, " must not have predecessors.");
+      release || assert (this.root.predecessors.length === 0, "Root node " + this.root + " must not have predecessors.");
 
       var dom = new Int32Array(this.blocks.length);
       for (var i = 0; i < dom.length; i++) {
@@ -1084,7 +1084,7 @@ module Shumway.AVM2.Compiler.IR {
       }
 
       function append(node) {
-        release || assert (!isScheduled(node), "Already scheduled ", node);
+        release || assert (!isScheduled(node), "Already scheduled " + node);
         scheduled[node.id] = true;
         release || assert (node.control, node);
         if (shouldFloat(node)) {
@@ -1157,7 +1157,7 @@ module Shumway.AVM2.Compiler.IR {
         if (node === dfg.start || node instanceof Region) {
           return;
         }
-        release || assert (node.control, "Node is not scheduled: ", node);
+        release || assert (node.control, "Node is not scheduled: " + node);
       });
     }
 

--- a/src/avm2/compiler/verifier.ts
+++ b/src/avm2/compiler/verifier.ts
@@ -561,7 +561,7 @@ module Shumway.AVM2.Verifier {
       State._mergeArrays(this.scope, other.scope);
     }
     private static _mergeArrays(a: Type [], b: Type []) {
-      release || assert(a.length === b.length, "a: ", a, " b: ", b);
+      release || assert(a.length === b.length, "a: " + a + " b: " + b);
       for (var i = a.length - 1; i >= 0; i--) {
         release || assert((a[i] !== undefined) && (b[i] !== undefined));
         if (a[i] === b[i]) {

--- a/src/avm2/runtime.ts
+++ b/src/avm2/runtime.ts
@@ -1523,7 +1523,7 @@ module Shumway.AVM2.Runtime {
    * is used, the scope object is passed in every time.
    */
   export function createFunction(mi, scope, hasDynamicScope, breakpoint = false) {
-    release || assert(!mi.isNative(), "Method should have a builtin: ", mi.name);
+    release || assert(!mi.isNative(), "Method should have a builtin: " + mi.name);
 
     if (mi.freeMethod) {
       if (hasDynamicScope) {

--- a/src/base/utilities.ts
+++ b/src/base/utilities.ts
@@ -247,14 +247,12 @@ module Shumway {
       throw new Error(message);
     }
 
-    export function assert(condition: any, ...args) {
+    export function assert(condition: any, message: any = "assertion failed") {
       if (condition === "") {     // avoid inadvertent false positive
         condition = true;
       }
       if (!condition) {
-        var message = Array.prototype.slice.call(arguments);
-        message.shift();
-        Debug.error(message.join(""));
+        Debug.error(message.toString());
       }
     }
 

--- a/src/gfx/remotingGfx.ts
+++ b/src/gfx/remotingGfx.ts
@@ -113,7 +113,7 @@ module Shumway.Remoting.GFX {
       } else {
         frame = this._frames[id];
       }
-      release || assert (frame, "Frame ", frame, " of ", id, " has not been sent yet.");
+      release || assert (frame, "Frame " + frame + " of " + id + " has not been sent yet.");
       return frame;
     }
 
@@ -401,7 +401,7 @@ module Shumway.Remoting.GFX {
         for (var i = 0; i < count; i++) {
           var childId = input.readInt();
           var child = context._makeFrame(childId);
-          release || assert (child, "Child ", childId, " of ", id, " has not been sent yet.");
+          release || assert (child, "Child " + childId + " of " + id + " has not been sent yet.");
           container.addChild(child);
         }
       }

--- a/src/swf/inflate.ts
+++ b/src/swf/inflate.ts
@@ -92,9 +92,9 @@ module Shumway.SWF {
 
   export function verifyDeflateHeader(bytes): void {
     var header = (bytes[0] << 8) | bytes[1];
-    release || assert((header & 0x0f00) === 0x0800, 'unknown compression method', 'inflate');
-    release || assert((header % 31) === 0, 'bad FCHECK', 'inflate');
-    release || assert(!(header & 0x20), 'FDICT bit set', 'inflate');
+    release || assert((header & 0x0f00) === 0x0800, 'inflate: unknown compression method');
+    release || assert((header % 31) === 0, 'inflate: bad FCHECK');
+    release || assert(!(header & 0x20), 'inflate: FDICT bit set');
   }
 
   export function createInflatedStream(bytes, outputLength: number) : Stream {
@@ -125,7 +125,7 @@ module Shumway.SWF {
         }
         var len = stream.getUint16(pos, true);
         var nlen = stream.getUint16(pos + 2, true);
-        release || assert((~nlen & 0xffff) === len, 'bad uncompressed block length', 'inflate');
+        release || assert((~nlen & 0xffff) === len, 'inflate: bad uncompressed block length');
         if (stream.end - pos < 4 + len) {
           throw InflateNoDataError;
         }
@@ -278,7 +278,7 @@ module Shumway.SWF {
     }
     var code = codeTable.codes[bitBuffer & ((1 << maxBits) - 1)];
     var len = code >> 16;
-    release || assert(len, 'bad encoding', 'inflate');
+    release || assert(len, 'inflate: bad encoding');
     stream.bitBuffer = bitBuffer >>> len;
     stream.bitLength = bitLength - len;
     return code & 0xffff;

--- a/src/swf/parser/button.ts
+++ b/src/swf/parser/button.ts
@@ -31,7 +31,7 @@ module Shumway.SWF.Parser {
       if (character.eob)
         break;
       var characterItem = dictionary[character.symbolId];
-      release || assert(characterItem, 'undefined character', 'button');
+      release || assert(characterItem, 'undefined character button');
       var cmd = {
         symbolId: characterItem.id,
         depth: character.depth,

--- a/src/swf/parser/image.ts
+++ b/src/swf/parser/image.ts
@@ -62,7 +62,7 @@ module Shumway.SWF.Parser {
       }
       chunks.push(bytes.subarray(begin, i));
     } while (i < n);
-    release || assert(image.width && image.height, 'bad image', 'jpeg');
+    release || assert(image.width && image.height, 'bad jpeg image');
     return chunks;
   }
 
@@ -135,7 +135,7 @@ module Shumway.SWF.Parser {
 
         if (tag.incomplete) {
           var tables = dictionary[0];
-          release || assert(tables, 'missing tables', 'jpeg');
+          release || assert(tables, 'missing jpeg tables');
           var header = tables.data;
           if (header && header.size) {
             chunks[0] = chunks[0].subarray(2);

--- a/src/swf/parser/label.ts
+++ b/src/swf/parser/label.ts
@@ -41,7 +41,7 @@ module Shumway.SWF.Parser {
       }
       if (record.hasFont) {
         font = dictionary[record.fontId];
-        release || assert(font, 'undefined font', 'label');
+        release || assert(font, 'undefined label font');
         codes = font.codes;
         dependencies.push(font.id);
         size = record.fontHeight / 20;
@@ -68,7 +68,7 @@ module Shumway.SWF.Parser {
       var entry;
       while ((entry = entries[j++])) {
         var code = codes[entry.glyphIndex];
-        release || assert(code, 'undefined glyph ', 'label');
+        release || assert(code, 'undefined label glyph');
         text += String.fromCharCode(code);
         coords.push(x, y);
         x += entry.advance;


### PR DESCRIPTION
The use of `...args` caused TypeScript to emit some silly code that did
some unnecessary copying of the `arguments` array, and the use of
`arguments` caused additional allocations.

This change removes `...args`; only one message argument is now allowed,
and you have to pre-concatenate. This only affected ~20 assertions.

This reduces the cumulative allocations done by the JS engine while
starting up the racing demo by 34%, from 192 MB to 127 MB. These
allocations wouldn't happen in release mode, but there are so many of
them that it's worth fixing them even for non-release mode.
