### PR TITLE
Fixes several swfdec AVM1 tests

### DIFF
--- a/src/avm1/interpreter.ts
+++ b/src/avm1/interpreter.ts
@@ -268,8 +268,7 @@ module Shumway.AVM1 {
       case 'movieclip':
         return (<Shumway.AVM2.AS.avm1lib.AS2MovieClip> value).__targetPath;
       case 'object':
-        var result = value.toString !== Function.prototype.toString ?
-          value.toString() : value;
+        var result = value.toString();
         if (typeof result === 'string') {
           return result;
         }


### PR DESCRIPTION
jsshell has less stack than browser, so swfdec/test/trace/stack-overflow is still failuing, however the first commit will fix the infinite recursion issue.
