### PR TITLE
Instrument

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -163,6 +163,13 @@ module.exports = function(grunt) {
       },
       tracetest_fuzz: {
         cmd: 'node test/trace_test_run.js -m test/test_manifest_fuzz.json'
+      },
+      instrument: {
+        cmd: function(path) {
+          var targetPath = path.replace(".swf", ".instrumented.swf");
+          console.info("Instrumenting " + path + " (" + targetPath + "), this may take a while if the file is large.");
+          return 'swfmill swf2xml ' + path + ' | xsltproc utils/instrument-swf.xslt - | swfmill xml2swf stdin ' + targetPath;
+        }
       }
     },
     parallel: {

--- a/utils/instrument-swf.xslt
+++ b/utils/instrument-swf.xslt
@@ -8,8 +8,7 @@
   To use this script you must first install swfmill and xsltproc. A typical use of this
   script looks something like this:
 
-    swfmill swf2xml file.swf file.xml
-    xsltproc utils/instrument-swf.xslt file.xml | swfmill xml2swf stdin file.instrumented.swf
+    swfmill swf2xml file.swf | xsltproc utils/instrument-swf.xslt - | swfmill xml2swf stdin file.instrumented.swf
 
 -->
 


### PR DESCRIPTION
This PR adds the ability to generate instrumented versions of SWF files that print out frame information. This is accomplished using `swfmill` and `xsltproc`:

`swf` -> `{swfmill swf2xml}` -> `xml` -> `xsltproc utils/instrument-swf.xslt` -> `xml` -> `{swfmill xml2swf}` -> `swf`.

I've tried this out on some larger files and it seems to work pretty well. Using this we should be able to generate trace output for more complicated ref tests, like games and such. Maybe we can just compare the first few hundred messages before any interactivity happens.

The XSLT transform emits `R frameNumber` for root frames, and `S spriteObjectID frameNumber` for sprites.
