### PR TITLE
Run frame scripts for objects not on stage, too

### DIFF
--- a/src/player/player.ts
+++ b/src/player/player.ts
@@ -339,11 +339,13 @@ module Shumway.Player {
         return;
       }
       this._stage.scaleX = this._stage.scaleY = stageScaleOption.value;
+      // The stage is required for frame event cycle processing.
+      DisplayObject._stage = this._stage;
       for (var i = 0; i < frameRateMultiplierOption.value; i++) {
         enterTimeline("eventLoop");
         var start = performance.now();
         Loader.progress();
-        DisplayObject.performFrameNavigation(this._stage, true, runFrameScripts);
+        DisplayObject.performFrameNavigation(true, runFrameScripts);
         counter.count("performFrameNavigation", 1, performance.now() - start);
         this._framesPlayed ++;
         if (tracePlayerOption.value > 0 && (this._framesPlayed % tracePlayerOption.value === 0)) {

--- a/test/unit/pass/MovieClip.js
+++ b/test/unit/pass/MovieClip.js
@@ -1,6 +1,7 @@
 (function timelineTests() {
   var assert = Shumway.Debug.assert;
   var LoaderInfo = flash.display.LoaderInfo;
+  var DisplayObject = flash.display.DisplayObject;
   var DisplayObjectContainer = flash.display.DisplayObjectContainer;
   var Stage = flash.display.Stage;
   var MovieClip = flash.display.MovieClip;
@@ -24,6 +25,7 @@
     assert(typeof numFrames === 'number');
     var loaderInfo = new LoaderInfo();
     var stage = new Stage();
+    DisplayObject._stage = stage;
     stage._stage = stage;
     var symbol = new SpriteSymbol(0);
     symbol.numFrames = numFrames;


### PR DESCRIPTION
@tobytailor disabused me of the idea that frame scripts are only run for on-stage objects, so this reverts that change from July.

Contains some semi-heavy refactoring of how the frame event cycle is run, to make this work nicer/at all.

Plus documentation of some test findings.
