### PR TITLE
Don't implement Flash's stroking model as a polyfill.

### DIFF
--- a/src/gfx/renderables/renderables.ts
+++ b/src/gfx/renderables/renderables.ts
@@ -446,8 +446,9 @@ module Shumway.GFX {
           context.fillStyle = 'transparent';
         } else if (!clipRegion) {
           context.strokeStyle = path.style;
+          var lineScaleMode = LineScaleMode.Normal;
           if (path.strokeProperties) {
-            context.lineScaleMode = path.strokeProperties.scaleMode;
+            lineScaleMode = path.strokeProperties.scaleMode;
             context.lineWidth = path.strokeProperties.thickness;
             context.lineCap = path.strokeProperties.capsStyle;
             context.lineJoin = path.strokeProperties.jointsStyle;
@@ -467,7 +468,7 @@ module Shumway.GFX {
           if (isSpecialCaseWidth) {
             context.translate(0.5, 0.5);
           }
-          context.stroke(path.path);
+          context.flashStroke(path.path, lineScaleMode);
           if (isSpecialCaseWidth) {
             context.translate(-0.5, -0.5);
           }


### PR DESCRIPTION
Follow up to previous patch. Main change here is that we don't overwrite the `stroke` function instead we create a new function called `flashStroke`.
