### PR TITLE
Warn about dropped tags in defineSymbol parsing

### DIFF
--- a/src/swf/resourceLoader.ts
+++ b/src/swf/resourceLoader.ts
@@ -127,6 +127,8 @@ module Shumway.SWF {
               commands = [];
               frame = { type: 'frame' };
               break;
+            default:
+              Debug.warning('Dropped tag during parsing. Code: ' + tag.code + ', ID: ' + tag.id);
           }
         }
         if (frames.length === 0) {
@@ -147,6 +149,8 @@ module Shumway.SWF {
       case SwfTag.CODE_DEFINE_TEXT2:
         symbol = Shumway.SWF.Parser.defineLabel(swfTag, symbols);
         break;
+      default:
+        Debug.warning('Dropped tag during parsing. Code: ' + tag.code + ', ID: ' + tag.id);
     }
 
     if (!symbol) {


### PR DESCRIPTION
Turns out we silently swallow nested symbols, which we would've found out much earlier with such a warning.
