### PR TITLE
Improvement to the FF extension's context menu

### DIFF
--- a/extension/firefox/content/ShumwayStreamConverter.jsm
+++ b/extension/firefox/content/ShumwayStreamConverter.jsm
@@ -472,25 +472,33 @@ ChromeActions.prototype = {
     }
   },
   reportIssue: function(exceptions) {
-    var base = "http://shumway-issue-reporter.paas.allizom.org/input?";
+    var urlTemplate = "https://bugzilla.mozilla.org/enter_bug.cgi?op_sys=All&priority=--" +
+                      "&rep_platform=All&target_milestone=---&version=Trunk&product=Firefox" +
+                      "&component=Shumway&short_desc=&comment={comment}" +
+                      "&bug_file_loc={url}";
     var windowUrl = this.window.parent.wrappedJSObject.location + '';
-    var params = 'url=' + encodeURIComponent(windowUrl);
-    params += '&swf=' + encodeURIComponent(this.url);
+    var url = urlTemplate.split('{url}').join(encodeURIComponent(windowUrl));
+    var params = {
+      swf: encodeURIComponent(this.url)
+    };
     getVersionInfo().then(function (versions) {
-      params += '&ffbuild=' + encodeURIComponent(versions.geckoMstone + ' (' +
-                                                 versions.geckoBuildID + ')');
-      params += '&shubuild=' + encodeURIComponent(versions.shumwayVersion);
+      params.versions = versions;
     }).then(function () {
-      var postDataStream = StringInputStream.
-                           createInstance(Ci.nsIStringInputStream);
-      postDataStream.data = 'exceptions=' + encodeURIComponent(exceptions);
-      var postData = MimeInputStream.createInstance(Ci.nsIMIMEInputStream);
-      postData.addHeader("Content-Type", "application/x-www-form-urlencoded");
-      postData.addContentLength = true;
-      postData.setData(postDataStream);
-      this.window.openDialog('chrome://browser/content', '_blank',
-                             'all,dialog=no', base + params, null, null,
-                             postData);
+      params.ffbuild = encodeURIComponent(params.versions.geckoMstone +
+                                          ' (' + params.versions.geckoBuildID + ')');
+      params.shubuild = encodeURIComponent(params.versions.shumwayVersion);
+      params.exceptions = encodeURIComponent(exceptions);
+      var comment = '%2B%2B%2B This bug was initially via the problem reporting functionality in ' +
+                    'Shumway %2B%2B%2B%0A%0A' +
+                    'Please add any further information that you deem helpful here:%0A%0A%0A' +
+                    '----------------------%0A%0A' +
+                    'Technical Information:%0A' +
+                    'Firefox version: ' + params.ffbuild + '%0A' +
+                    'Shumway version: ' + params.shubuild;
+      url = url.split('{comment}').join(comment);
+      //this.window.openDialog('chrome://browser/content', '_blank', 'all,dialog=no', url);
+      dump(111);
+      this.window.open(url);
     }.bind(this));
   },
   externalCom: function (data) {

--- a/extension/firefox/content/web/viewer.html
+++ b/extension/firefox/content/web/viewer.html
@@ -106,7 +106,8 @@ limitations under the License.
         <menuitem label="Show URL" id="showURLMenu"></menuitem>
         <menuitem label="Open in Inspector" id="inspectorMenu"></menuitem>
         <menuitem label="Report Problems" id="reportMenu"></menuitem>
-        <menuitem label="Fallback to Flash" id="fallbackMenu" hidden></menuitem>
+        <menuitem label="Reload in Adobe Flash Player" id="fallbackMenu" hidden></menuitem>
+        <menuitem label="About Shumway" id="aboutMenu"></menuitem>
       </menu>
     </section>
   </body>

--- a/extension/firefox/content/web/viewer.js
+++ b/extension/firefox/content/web/viewer.js
@@ -144,12 +144,10 @@ function runViewer() {
     fallbackMenu.removeAttribute('hidden');
     fallbackMenu.addEventListener('click', fallback);
   }
-  var showURLMenu = document.getElementById('showURLMenu');
-  showURLMenu.addEventListener('click', showURL);
-  var inspectorMenu = document.getElementById('inspectorMenu');
-  inspectorMenu.addEventListener('click', showInInspector);
-  var reportMenu = document.getElementById('reportMenu');
-  reportMenu.addEventListener('click', reportIssue);
+  document.getElementById('showURLMenu').addEventListener('click', showURL);
+  document.getElementById('inspectorMenu').addEventListener('click', showInInspector);
+  document.getElementById('reportMenu').addEventListener('click', reportIssue);
+  document.getElementById('aboutMenu').addEventListener('click', showAbout);
 }
 
 function showURL() {
@@ -166,23 +164,28 @@ function showInInspector() {
 }
 
 function reportIssue() {
-  var duplicatesMap = Object.create(null);
-  var prunedExceptions = [];
-  avm2.exceptions.forEach(function(e) {
-    var ident = e.source + e.message + e.stack;
-    var entry = duplicatesMap[ident];
-    if (!entry) {
-      entry = duplicatesMap[ident] = {
-        source: e.source,
-        message: e.message,
-        stack: e.stack,
-        count: 0
-      };
-      prunedExceptions.push(entry);
-    }
-    entry.count++;
-  });
-  FirefoxCom.requestSync('reportIssue', JSON.stringify(prunedExceptions));
+  //var duplicatesMap = Object.create(null);
+  //var prunedExceptions = [];
+  //avm2.exceptions.forEach(function(e) {
+  //  var ident = e.source + e.message + e.stack;
+  //  var entry = duplicatesMap[ident];
+  //  if (!entry) {
+  //    entry = duplicatesMap[ident] = {
+  //      source: e.source,
+  //      message: e.message,
+  //      stack: e.stack,
+  //      count: 0
+  //    };
+  //    prunedExceptions.push(entry);
+  //  }
+  //  entry.count++;
+  //});
+  //FirefoxCom.requestSync('reportIssue', JSON.stringify(prunedExceptions));
+  FirefoxCom.requestSync('reportIssue');
+}
+
+function showAbout() {
+  window.open('http://areweflashyet.com/');
 }
 
 var movieUrl, movieParams, objectParams;


### PR DESCRIPTION
Specifically:
- Bug 1068342 - Add a "Reload in Adobe Flash Player" context menu item to fallback back from Shumway to Flash (we had this under a different name)
- Bug 1064435 - Add "About Shumway [version]" context menu item, like Flash plugin's "About Adobe Flash Player [version]" (without the [version] part for now, because that's a bit annoying to do/hard to make work without introducing startup time regressions)
- Bug 1064005 - Shumway "Report Problems" context menu item does nothing: ReferenceError: avm2 is not defined viewer.js:171
- No Bug - change the "Report Problems" entry to open a bugzilla.mozilla.org bug entry form prefilled with some useful information and set to the correct component
