### PR TITLE
Change reftest server's port to 8080

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -54,7 +54,7 @@ function parseOptions() {
     .describe('reftest', 'Automatically start reftest showing comparison ' +
       'test failures, if there are any.')
     .describe('port', 'The port the HTTP server should listen on.')
-    .default('port', 8000)
+    .default('port', 8080)
     .describe('statsFile', 'The file where to store stats.')
     .describe('statsDelay', 'The amount of time in milliseconds the browser ' +
       'should wait before starting stats.')


### PR DESCRIPTION
That's where the Python-based server ran, and it doesn't conflict with `grunt server`.
