### PR TITLE
Bug 1080750 - Shumway extension should set "shumway.ignoreCTP" pref

### DIFF
--- a/extension/firefox/bootstrap.js
+++ b/extension/firefox/bootstrap.js
@@ -87,7 +87,7 @@ function startup(aData, aReason) {
   overlayConverterFactory.register(ShumwayStreamOverlayConverter);
 
   if (registerOverlayPreview) {
-    var ignoreCTP = getBoolPref('shumway.ignoreCTP', false);
+    var ignoreCTP = getBoolPref('shumway.ignoreCTP', true);
     Ph.registerPlayPreviewMimeType('application/x-shockwave-flash', ignoreCTP);
   }
 }


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1080750
