### PR TITLE
Delay all immediately-executed ABC blocks until all frame assets have been resolved

### DIFF
--- a/src/flash/display/Loader.ts
+++ b/src/flash/display/Loader.ts
@@ -385,22 +385,28 @@ module Shumway.AVM2.AS.flash.display {
               suspendUntil = Promise.all(this._frameAssetsQueue).then(function () {
                 self._enqueueFrame(data);
                 self._frameAssetsQueue = null;
-              }.bind(this));
+              });
             } else {
               this._enqueueFrame(data);
             }
           } else if (data.type === 'image') {
             this._commitImage(data);
           } else if (data.type === 'abc') {
-            var appDomain = AVM2.instance.applicationDomain;
-            var abc = new AbcFile(data.data, data.name);
-            if (data.flags) {
-              // kDoAbcLazyInitializeFlag = 1 Indicates that the ABC block should not be executed
-              // immediately.
-              appDomain.loadAbc(abc);
-            } else {
-              if (loaderInfo._allowCodeExecution) {
-                appDomain.executeAbc(abc);
+            if (loaderInfo._allowCodeExecution) {
+              var appDomain = AVM2.instance.applicationDomain;
+              var abc = new AbcFile(data.data, data.name);
+              if (data.flags) {
+                // kDoAbcLazyInitializeFlag = 1 Indicates that the ABC block should not be executed
+                // immediately.
+                appDomain.loadAbc(abc);
+              } else {
+                if (this._frameAssetsQueue) {
+                  suspendUntil = Promise.all(this._frameAssetsQueue).then(function () {
+                    appDomain.executeAbc(abc);
+                  });
+                } else {
+                  appDomain.executeAbc(abc);
+                }
               }
             }
           }


### PR DESCRIPTION
An ABC block can and, in many cases, will rely on other assets being available. It might rely on the fact that an embedded image comes before it in the SWF file, so it can safely just access the image. In delaying the ABC block's execution until all previous assets have become available, we guarantee that that actually works.

(Note: that's not the end of the story, sadly. Code also can rely on just the `bytesLoaded` value matching some expectations, so we have to delay reporting bytes as loaded until their contents are fully available, too. But that's for another bug.)
