### PR TITLE
Fix regression causing exceptions in deserializing registerFont messages in the GFX backend

### DIFF
--- a/src/gfx/remotingGfx.ts
+++ b/src/gfx/remotingGfx.ts
@@ -568,7 +568,10 @@ module Shumway.Remoting.GFX {
     }
 
     private _readRegisterFont() {
-      var fontId = this.input.readInt();
+      var input = this.input;
+      var fontId = input.readInt();
+      var bold = input.readBoolean();
+      var italic = input.readBoolean();
       var data = this._readAsset();
       Shumway.registerCSSFont(fontId, data);
     }


### PR DESCRIPTION
Embarassing, but not actually harmful right now, because the message always ends right afterwards, and we currently register the font twice anyway: the player and GFX backend run in the same window, after all.
