### PR TITLE
Passes movie params via LoaderContext

### DIFF
--- a/examples/inspector/js/inspector.js
+++ b/examples/inspector/js/inspector.js
@@ -36,6 +36,7 @@ var simpleMode = getQueryVariable("simpleMode") === "true";
 var pauseExecution = getQueryVariable("paused") === "true";
 var remoteFile = getQueryVariable("rfile");
 var yt = getQueryVariable('yt');
+var movieParams = parseQueryString(getQueryVariable('flashvars'));
 
 //var swfController = new SWFController(timeline, pauseExecution);
 
@@ -82,7 +83,7 @@ function parseQueryString(qs) {
  */
 if (remoteFile) {
   setTimeout(function () {
-    executeFile(remoteFile, null, parseQueryString(window.location.search));
+    executeFile(remoteFile, null, movieParams);
   });
 } else if (yt) {
   requestYT(yt).then(function (config) {
@@ -175,6 +176,8 @@ function executeFile(file, buffer, movieParams) {
         });
         syncGFXOptions(easel.options);
         var player = new Shumway.Player.Test.TestPlayer();
+        player.movieParams = movieParams;
+
         easelHost = new Shumway.GFX.Test.TestEaselHost(easel);
         player.load(file, buffer);
 

--- a/examples/inspector/js/inspectorPlayer.js
+++ b/examples/inspector/js/inspectorPlayer.js
@@ -108,6 +108,7 @@ function runSwfPlayer(data) {
   Shumway.createAVM2(builtinPath, playerglobalInfo, avm1Path, sysMode, appMode, function (avm2) {
     function runSWF(file) {
       var player = new Shumway.Player.Window.WindowPlayer(window);
+      player.movieParams = movieParams;
       player.load(file);
     }
     file = Shumway.FileLoadingService.instance.setBaseUrl(file);

--- a/extension/firefox/content/web/viewerPlayer.js
+++ b/extension/firefox/content/web/viewerPlayer.js
@@ -49,6 +49,7 @@ function runSwfPlayer(flashParams) {
     function runSWF(file) {
       var player = new Shumway.Player.Window.WindowPlayer(window, window.parent);
       player.defaultStageColor = flashParams.bgcolor;
+      player.movieParams = flashParams.movieParams;
 
       Shumway.ExternalInterfaceService.instance = player.createExternalInterfaceService();
 

--- a/src/flash/display/Loader.ts
+++ b/src/flash/display/Loader.ts
@@ -812,8 +812,6 @@ module Shumway.AVM2.AS.flash.display {
           }
           parameters[key] = value;
         }
-      } else {
-        // TODO: parse request URL parameters.
       }
       if (context && context.applicationDomain) {
         this._contentLoaderInfo._applicationDomain =

--- a/src/flash/linker.ts
+++ b/src/flash/linker.ts
@@ -185,6 +185,7 @@ module Shumway.AVM2.AS {
       M("flash.system.SecurityDomain", "SecurityDomainClass", flash.system.SecurityDomain),
       M("flash.system.ApplicationDomain", "ApplicationDomainClass", flash.system.ApplicationDomain),
       M("flash.system.JPEGLoaderContext", "JPEGLoaderContextClass", flash.system.JPEGLoaderContext),
+      M("flash.system.LoaderContext", "LoaderContextClass", flash.system.LoaderContext),
 
       M("flash.accessibility.Accessibility", "AccessibilityClass",
         flash.accessibility.Accessibility),

--- a/src/flash/system/LoaderContext.as
+++ b/src/flash/system/LoaderContext.as
@@ -17,6 +17,7 @@
 package flash.system {
 import flash.display.DisplayObjectContainer;
 
+[native(cls='LoaderContextClass')]
 public class LoaderContext {
   public function LoaderContext(checkPolicyFile:Boolean = false,
                                 applicationDomain:ApplicationDomain = null,

--- a/src/flash/system/LoaderContext.ts
+++ b/src/flash/system/LoaderContext.ts
@@ -30,7 +30,7 @@ module Shumway.AVM2.AS.flash.system {
     static classSymbols: string [] = null; // [];
     
     // List of instance symbols to link.
-    static instanceSymbols: string [] = null; // ["checkPolicyFile", "applicationDomain", "securityDomain", "allowCodeImport", "requestedContentParent", "parameters", "imageDecodingPolicy"];
+    static instanceSymbols: string [] = ["checkPolicyFile!", "applicationDomain!", "securityDomain!", "allowCodeImport!", "requestedContentParent!", "parameters!", "imageDecodingPolicy!"];
     
     constructor (checkPolicyFile: boolean = false, applicationDomain: flash.system.ApplicationDomain = null, securityDomain: flash.system.SecurityDomain = null) {
       checkPolicyFile = !!checkPolicyFile; applicationDomain = applicationDomain; securityDomain = securityDomain;

--- a/src/player/player.ts
+++ b/src/player/player.ts
@@ -93,6 +93,11 @@ module Shumway.Player {
     public defaultStageColor: number;
 
     /**
+     * Movie parameters, such as flashvars.
+     */
+    public movieParams: Map<string>;
+
+    /**
      * Time since the last time we've synchronized the display list.
      */
     private _lastPumpTime = 0;
@@ -171,14 +176,27 @@ module Shumway.Player {
           self._enterLoops();
         });
       }
+      var context = this.createLoaderContext();
       if (buffer) {
         var symbol = Shumway.Timeline.BinarySymbol.FromData({id: -1, data: buffer});
         var byteArray = symbol.symbolClass.initializeFrom(symbol);
         symbol.symbolClass.instanceConstructorNoInitialize.call(byteArray);
-        this._loader.loadBytes(byteArray);
+        this._loader.loadBytes(byteArray, context);
       } else {
-        this._loader.load(new flash.net.URLRequest(url));
+        this._loader.load(new flash.net.URLRequest(url), context);
       }
+    }
+
+    private createLoaderContext() : flash.system.LoaderContext {
+      var loaderContext = new flash.system.LoaderContext();
+      if (this.movieParams) {
+        var parameters: any = {};
+        for (var i in this.movieParams) {
+          parameters.asSetPublicProperty(i, this.movieParams[i]);
+        }
+        loaderContext.parameters = <Shumway.AVM2.AS.ASObject>parameters;
+      }
+      return loaderContext;
     }
 
     public processUpdates(updates: DataBuffer, assets: any []) {


### PR DESCRIPTION
To pass parameters to the movie from the inspector, the `flashvar` parameter shall be used.
