### PR TITLE
Fixes displayParameters on retina displays.

### DIFF
--- a/examples/inspector/js/inspector.js
+++ b/examples/inspector/js/inspector.js
@@ -128,7 +128,7 @@ function runIFramePlayer(data) {
 
     data.type = 'runSwf';
     data.settings = Shumway.Settings.getSettings();
-    data.displayParams = easel.getDisplayParameters();
+    data.displayParameters = easel.getDisplayParameters();
 
     var playerWorker = playerWorkerIFrame.contentWindow;
     playerWorker.postMessage(data, '*');
@@ -191,7 +191,7 @@ function executeFile(file, buffer, movieParams) {
         player.movieParams = movieParams;
         player.stageAlign = state.salign;
         player.stageScale = state.scale;
-        player.displayParams = easel.getDisplayParameters();
+        player.displayParameters = easel.getDisplayParameters();
 
         easelHost = new Shumway.GFX.Test.TestEaselHost(easel);
         player.load(file, buffer);

--- a/examples/inspector/js/inspectorPlayer.js
+++ b/examples/inspector/js/inspectorPlayer.js
@@ -106,7 +106,7 @@ function runSwfPlayer(data) {
   var movieParams = data.movieParams;
   var stageAlign = data.stageAlign;
   var stageScale = data.stageScale;
-  var displayParams = data.displayParams;
+  var displayParameters = data.displayParameters;
   var file = data.file;
   configureMocks(file);
   Shumway.createAVM2(builtinPath, playerglobalInfo, avm1Path, sysMode, appMode, function (avm2) {
@@ -115,7 +115,7 @@ function runSwfPlayer(data) {
       player.movieParams = movieParams;
       player.stageAlign = stageAlign;
       player.stageScale = stageScale;
-      player.displayParams = displayParams;
+      player.displayParameters = displayParameters;
       player.load(file);
     }
     file = Shumway.FileLoadingService.instance.setBaseUrl(file);

--- a/extension/firefox/content/web/viewer.js
+++ b/extension/firefox/content/web/viewer.js
@@ -273,7 +273,7 @@ function parseSwf(url, movieParams, objectParams) {
   easelHost = new Shumway.GFX.Window.WindowEaselHost(easel, playerWindow, window);
   easelHost.processExternalCommand = processExternalCommand;
 
-  var displayParams = easel.getDisplayParameters();
+  var displayParameters = easel.getDisplayParameters();
   var data = {
     type: 'runSwf',
     settings: Shumway.Settings.getSettings(),
@@ -281,7 +281,7 @@ function parseSwf(url, movieParams, objectParams) {
       compilerSettings: compilerSettings,
       movieParams: movieParams,
       objectParams: objectParams,
-      displayParams: displayParams,
+      displayParameters: displayParameters,
       turboMode: turboMode,
       bgcolor: backgroundColor,
       url: url,

--- a/extension/firefox/content/web/viewerPlayer.js
+++ b/extension/firefox/content/web/viewerPlayer.js
@@ -51,7 +51,7 @@ function runSwfPlayer(flashParams) {
       player.movieParams = flashParams.movieParams;
       player.stageAlign = (objectParams && (objectParams.salign || objectParams.align)) || '';
       player.stageScale = (objectParams && objectParams.scale) || 'showall';
-      player.displayParams = flashParams.displayParams;
+      player.displayParameters = flashParams.displayParameters;
 
       Shumway.ExternalInterfaceService.instance = player.createExternalInterfaceService();
 

--- a/src/base/remoting.ts
+++ b/src/base/remoting.ts
@@ -190,8 +190,8 @@ module Shumway.Remoting {
   }
 
   export interface DisplayParameters {
-    canvasWidth: number;
-    canvasHeight: number;
+    stageWidth: number;
+    stageHeight: number;
     pixelRatio: number;
     screenWidth: number;
     screenHeight: number;

--- a/src/gfx/easel.ts
+++ b/src/gfx/easel.ts
@@ -472,11 +472,10 @@ module Shumway.GFX {
     }
 
     getDisplayParameters(): DisplayParameters {
-      var container = this._container;
       var ratio = this.getRatio();
       return {
-        canvasWidth: container.offsetWidth / ratio,
-        canvasHeight: container.offsetHeight / ratio,
+        stageWidth: this._containerWidth,
+        stageHeight: this._containerHeight,
         pixelRatio: ratio,
         screenWidth: window.screen ? window.screen.width : 640,
         screenHeight: window.screen ? window.screen.height : 480

--- a/src/player/player.ts
+++ b/src/player/player.ts
@@ -112,7 +112,7 @@ module Shumway.Player {
     /**
      * Initial display parameters.
      */
-    public displayParams: DisplayParameters;
+    public displayParameters: DisplayParameters;
 
     /**
      * Time since the last time we've synchronized the display list.
@@ -193,8 +193,8 @@ module Shumway.Player {
           stage.setStageColor(ColorUtilities.RGBAToARGB(bgcolor));
           stage.addTimelineObjectAtDepth(root, 0);
 
-          if (self.displayParams) {
-            self.processDisplayParameters(self.displayParams);
+          if (self.displayParameters) {
+            self.processDisplayParameters(self.displayParameters);
           }
 
           self._enterLoops();
@@ -608,8 +608,8 @@ module Shumway.Player {
       listener(eventType, data);
     }
 
-    public processDisplayParameters(params: DisplayParameters) {
-      this._stage.setCanvasSize(params.canvasWidth, params.canvasHeight, params.pixelRatio);
+    public processDisplayParameters(displayParameters: DisplayParameters) {
+      this._stage.setStageContainerSize(displayParameters.stageWidth, displayParameters.stageHeight, displayParameters.pixelRatio);
     }
 
     onExternalCommand(command) {

--- a/test/harness/slave.js
+++ b/test/harness/slave.js
@@ -118,7 +118,7 @@ function loadMovie(path, reportFrames) {
       player = new Shumway.Player.Test.TestPlayer();
       player.stageAlign = 'tl';
       player.stageScale = 'noscale';
-      player.displayParams = easel.getDisplayParameters();
+      player.displayParameters = easel.getDisplayParameters();
       player.load(path);
 
     });


### PR DESCRIPTION
Renames canvasWidth/Height to stageWidth/Height and removes ratio computation.
Only fires the resize event if things have actually changed.
Assertions to make sure we have a valid container size.
