### PR TITLE
Makes button as dynamic symbol

### DIFF
--- a/src/flash/display/SimpleButton.ts
+++ b/src/flash/display/SimpleButton.ts
@@ -283,7 +283,7 @@ module Shumway.AVM2.AS.flash.display {
     loaderInfo: flash.display.LoaderInfo;
 
     constructor(data: Timeline.SymbolData, loaderInfo: flash.display.LoaderInfo) {
-      super(data, flash.display.SimpleButton, false);
+      super(data, flash.display.SimpleButton, true);
       this.loaderInfo = loaderInfo;
     }
 


### PR DESCRIPTION
Fixes "Fill or Line bounds are not defined in the symbol." warnings and buttons behavior on the timeline.
