### PR TITLE
Default DisplayObject#ratio to 0 instead of -1

### DIFF
--- a/src/flash/display/DisplayObject.ts
+++ b/src/flash/display/DisplayObject.ts
@@ -406,7 +406,7 @@ module Shumway.AVM2.AS.flash.display {
       self._concatenatedColorTransform = new geom.ColorTransform();
 
       self._depth = -1;
-      self._ratio = -1;
+      self._ratio = 0;
       self._index = -1;
       self._maskedObject = null;
 
@@ -1088,8 +1088,9 @@ module Shumway.AVM2.AS.flash.display {
       }
 
       if (placeObjectTag.flags & PlaceObjectFlags.HasRatio || reset) {
-        var ratio = placeObjectTag.ratio === undefined ? -1 : placeObjectTag.ratio;
+        var ratio = placeObjectTag.ratio | 0;
         if (ratio !== this._ratio) {
+          release || assert(ratio >= 0 && ratio <= 0xffff);
           this._ratio = ratio;
           this._setDirtyFlags(DisplayObjectFlags.DirtyMiscellaneousProperties);
         }

--- a/src/flash/display/MorphShape.ts
+++ b/src/flash/display/MorphShape.ts
@@ -51,8 +51,7 @@ module Shumway.AVM2.AS.flash.display {
     _containsPointDirectly(localX: number, localY: number,
                            globalX: number, globalY: number): boolean {
       var graphics = this._getGraphics();
-      return graphics && graphics._containsPoint(localX, localY, true,
-                                                 this._ratio > -1 ? this._ratio / 0xffff : 0);
+      return graphics && graphics._containsPoint(localX, localY, true, this._ratio / 0xffff);
     }
   }
 

--- a/src/flash/display/Sprite.ts
+++ b/src/flash/display/Sprite.ts
@@ -108,8 +108,7 @@ module Shumway.AVM2.AS.flash.display {
             }
           }
           // If no such tag was found or a different object is placed, remove the current child.
-          if (!tag || child._symbol.id !== tag.symbolId ||
-              child._ratio !== (tag.ratio === undefined ? -1 : tag.ratio)) {
+          if (!tag || child._symbol.id !== tag.symbolId || child._ratio !== (tag.ratio | 0)) {
             this._removeAnimatedChild(child);
           }
         }

--- a/src/gfx/remotingGfx.ts
+++ b/src/gfx/remotingGfx.ts
@@ -564,6 +564,7 @@ module Shumway.Remoting.GFX {
       }
       if (hasBits & MessageBits.HasMiscellaneousProperties) {
         ratio = input.readInt() / 0xffff;
+        release || assert(ratio >= 0 && ratio <= 1);
         var blendMode = input.readInt();
         if (blendMode !== BlendMode.Normal) {
           node.getLayer().blendMode = blendMode;


### PR DESCRIPTION
There's no need to special case this at all: absense of a defined ratio implies `0`. Fixes an issue where we were passing negative values to canvas gradients for morph shapes.