### PR TITLE
Give all evaluated functions sourceURLs

### DIFF
--- a/src/avm2/native.ts
+++ b/src/avm2/native.ts
@@ -507,17 +507,20 @@ module Shumway.AVM2.AS {
           var qn = Multiname.getQualifiedName(trait.name);
           if (trait.isSlot()) {
             Object.defineProperty(object, name, {
-              get: <() => any>new Function("", "return this." + qn),
-              set: <(any) => void>new Function("v", "this." + qn + " = v")
+              get: <() => any>new Function("", "return this." + qn +
+                                               "//# sourceURL=get-" + qn + ".as"),
+              set: <(any) => void>new Function("v", "this." + qn + " = v;" +
+                                                    "//# sourceURL=set-" + qn + ".as")
             });
           } else if (trait.isMethod()) {
-            release || assert (!object[name], "Symbol should not already exist.")
+            release || assert (!object[name], "Symbol should not already exist.");
             release || assert (object.asOpenMethods[qn], "There should be an open method for this symbol.");
             object[name] = object.asOpenMethods[qn];
           } else if (trait.isGetter()) {
             release || assert (hasOwnGetter(object, qn), "There should be an getter method for this symbol.");
             Object.defineProperty(object, name, {
-              get: <() => any>new Function("", "return this." + qn),
+              get: <() => any>new Function("", "return this." + qn +
+                                               "//# sourceURL=get-" + qn + ".as")
             });
           } else {
             notImplemented(trait);

--- a/src/avm2/runtime.ts
+++ b/src/avm2/runtime.ts
@@ -411,8 +411,13 @@ module Shumway.AVM2.Runtime {
     return self.asSetProperty(undefined, name, 0, value);
   }
 
-  export var forwardValueOf: () => any = <any>new Function("", 'return this.' + Multiname.VALUE_OF + ".apply(this, arguments)");
-  export var forwardToString: () => string = <any>new Function("", 'return this.' + Multiname.TO_STRING + ".apply(this, arguments)");
+  export var forwardValueOf: () => any = <any>new Function("", 'return this.' + Multiname.VALUE_OF +
+                                                               ".apply(this, arguments)" +
+                                                               "//# sourceURL=forward-valueOf.as");
+  export var forwardToString: () => string = <any>new Function("", 'return this.' +
+                                                                   Multiname.TO_STRING +
+                                                                   ".apply(this, arguments)" +
+                                                                   "//# sourceURL=forward-toString.as");
 
   /**
    * Patches the |object|'s toString properties with a forwarder that calls the AS3 toString. We only do this when
@@ -1524,6 +1529,7 @@ module Shumway.AVM2.Runtime {
     }
     if (!cached) {
       var fnSource = "function " + fnName + " (" + compilation.parameters.join(", ") + ") " + body;
+      fnSource += "//# sourceURL=fun-" + fnName + ".as";
     }
 
     if (!release) {

--- a/src/base/utilities.ts
+++ b/src/base/utilities.ts
@@ -15,7 +15,7 @@
  */
 
 ///<reference path='references.ts' />
-var jsGlobal = (function() { return this || (1, eval)('this'); })();
+var jsGlobal = (function() { return this || (1, eval)('this//# sourceURL=jsGlobal-getter'); })();
 // Our polyfills for some DOM things make testing this slightly more onerous than it ought to be.
 var inBrowser = typeof window !=='undefined' && 'document' in window && 'plugins' in window.document;
 var inFirefox = typeof navigator !== 'undefined' && navigator.userAgent.indexOf('Firefox') >= 0;
@@ -833,11 +833,13 @@ module Shumway {
 
   export module FunctionUtilities {
     export function makeForwardingGetter(target: string): () => any {
-      return <() => any> new Function("return this[\"" + target + "\"]");
+      return <() => any> new Function("return this[\"" + target + "\"]//# sourceURL=fwd-get-" +
+                                      target + ".as");
     }
 
     export function makeForwardingSetter(target: string): (any) => void {
-      return <(any) => void> new Function("value", "this[\"" + target + "\"] = value;");
+      return <(any) => void> new Function("value", "this[\"" + target + "\"] = value;" +
+                                                   "//# sourceURL=fwd-set-" + target + ".as");
     }
 
     /**


### PR DESCRIPTION
This makes them show up under their `sourceURL` in the debugger and in stack traces.