### PR TITLE
Properly detach a videos net stream

### DIFF
--- a/src/flash/media/Video.ts
+++ b/src/flash/media/Video.ts
@@ -83,7 +83,7 @@ module Shumway.AVM2.AS.flash.media {
         return;
       }
       if (this._netStream) {
-        netStream._videoReferrer = null;
+        this._netStream._videoReferrer = null;
       }
       this._netStream = netStream;
       if (this._netStream) {


### PR DESCRIPTION
Handles the case where null is passed to Video::attachNetStream to stop a video from playing in a Video object. Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1119677.