### PR TITLE
Bug 1130397 - Change usages of asApply to apply where possible

### DIFF
--- a/src/avm2/natives/xml.ts
+++ b/src/avm2/natives/xml.ts
@@ -2431,14 +2431,9 @@ module Shumway.AVM2.AS {
       // Checking if the method exists before calling it
       var method;
       var resolved = this.resolveMultinameProperty(namespaces, name, flags);
-      if (this.asGetNumericProperty && Multiname.isNumeric(resolved)) {
-        method = this.asGetNumericProperty(resolved);
-      } else {
-        var openMethods = this.asOpenMethods;
-        method = (openMethods && openMethods[resolved]) || this[resolved];
-      }
+      method = this.asOpenMethods[resolved] || this[resolved];
       if (method) {
-        return method.asApply(isLex ? null : this, args);
+        return method.apply(isLex ? null : this, args);
       }
       // Otherwise, 11.2.2.1 CallMethod ( r , args )
       // If f == undefined and Type(base) is XMLList and base.[[Length]] == 1
@@ -2450,7 +2445,7 @@ module Shumway.AVM2.AS {
       if (this.hasSimpleContent()) {
         return Object(toString(this)).asCallProperty(namespaces, name, flags, isLex, args);
       }
-      throw new TypeError();
+      throwError('TypeError', Errors.CallOfNonFunctionError, 'value');
     }
 
     _delete(key, isMethod) {
@@ -3455,14 +3450,9 @@ module Shumway.AVM2.AS {
       // Checking if the method exists before calling it
       var method;
       var resolved = this.resolveMultinameProperty(namespaces, name, flags);
-      if (this.asGetNumericProperty && Multiname.isNumeric(resolved)) {
-        method = this.asGetNumericProperty(resolved);
-      } else {
-        var openMethods = this.asOpenMethods;
-        method = (openMethods && openMethods[resolved]) || this[resolved];
-      }
+      method = this.asOpenMethods[resolved] || this[resolved];
       if (method) {
-        return method.asApply(isLex ? null : this, args);
+        return method.apply(isLex ? null : this, args);
       }
       // Otherwise, 11.2.2.1 CallMethod ( r , args )
       // If f == undefined and Type(base) is XMLList and base.[[Length]] == 1
@@ -3470,7 +3460,7 @@ module Shumway.AVM2.AS {
       if (this.length() === 1) {
         return this._children[0].asCallProperty(namespaces, name, flags, isLex, args);
       }
-      throw new TypeError();
+      throwError('TypeError', Errors.CallOfNonFunctionError, 'value');
     }
   }
 }

--- a/src/avm2/scope.ts
+++ b/src/avm2/scope.ts
@@ -47,9 +47,9 @@ module Shumway.AVM2.Runtime {
   }
 
   /**
-   * Scopes are used to emulate the scope stack as a linked list of scopes, rather than a stack. Each
-   * scope holds a reference to a scope [object] (which may exist on multiple scope chains, thus preventing
-   * us from chaining the scope objects together directly).
+   * Scopes are used to emulate the scope stack as a linked list of scopes, rather than a stack.
+   * Each scope holds a reference to a scope [object] (which may exist on multiple scope chains,
+   * thus preventing us from chaining the scope objects together directly).
    *
    * Scope Operations:
    *
@@ -58,13 +58,14 @@ module Shumway.AVM2.Runtime {
    *  get global scope: scope.global
    *  get scope object: scope.object
    *
-   * Method closures have a [savedScope] property which is bound when the closure is created. Since we use a
-   * linked list of scopes rather than a scope stack, we don't need to clone the scope stack, we can bind
-   * the closure to the current scope.
+   * Method closures have a [savedScope] property which is bound when the closure is created. Since
+   * we use a linked list of scopes rather than a scope stack, we don't need to clone the scope
+   * stack, we can bind the closure to the current scope.
    *
-   * The "scope stack" for a method always starts off as empty and methods push and pop scopes on their scope
-   * stack explicitly. If a property is not found on the current scope stack, it is then looked up
-   * in the [savedScope]. To emulate this we actually wrap every generated function in a closure, such as
+   * The "scope stack" for a method always starts off as empty and methods push and pop scopes on
+   * their scope stack explicitly. If a property is not found on the current scope stack, it is
+   * then looked up in the [savedScope]. To emulate this we actually wrap every generated function
+   * in a closure, such as
    *
    *  function fnClosure(scope) {
    *    return function fn() {
@@ -72,14 +73,16 @@ module Shumway.AVM2.Runtime {
    *    };
    *  }
    *
-   * When functions are created, we bind the function to the current scope, using fnClosure.bind(null, this)();
+   * When functions are created, we bind the function to the current scope, using
+   * fnClosure.bind(null, this)();
    *
    * Scope Caching:
    *
-   * Calls to |findScopeProperty| are very expensive. They recurse all the way to the top of the scope chain and then
-   * laterally across other scripts. We optimize this by caching property lookups in each scope using Multiname
-   * |id|s as keys. Each Multiname object is given a unique ID when it's constructed. For QNames we only cache
-   * string QNames.
+   * Calls to |findScopeProperty| are very expensive. They recurse all the way to the top of the
+   * scope chain and then laterally across other scripts. We optimize this by caching property
+   * lookups in each scope using Multiname
+   * |id|s as keys. Each Multiname object is given a unique ID when it's constructed. For QNames we
+   * only cache string QNames.
    *
    * TODO: This is not sound, since you can add/delete properties to/from with scopes.
    */
@@ -124,9 +127,10 @@ module Shumway.AVM2.Runtime {
     }
 
     /**
-     * Searches the scope stack for the object containing the specified property. If |strict| is specified then throw
-     * an exception if the property is not found. If |scopeOnly| is specified then only search the scope chain and not
-     * any of the top level domains (this is used by the verifier to bake in direct object references).
+     * Searches the scope stack for the object containing the specified property. If |strict| is
+     * specified then throw an exception if the property is not found. If |scopeOnly| is specified
+     * then only search the scope chain and not any of the top level domains (this is used by the
+     * verifier to bake in direct object references).
      *
      * Property lookups are cached in scopes but are not used when only looking at |scopesOnly|.
      */
@@ -201,11 +205,14 @@ module Shumway.AVM2.Runtime {
       }
     }
     if (!boundMethod) {
-      countTimeline("Bind Scope - Slow Path");
+      release || countTimeline("Bind Scope - Slow Path");
       boundMethod = function () {
-        Array.prototype.unshift.call(arguments, scope);
+        var args = [scope];
+        for (var i = 0; i < arguments.length; i++) {
+          args.push(arguments[i]);
+        }
         var global = (this === jsGlobal ? scope.global.object : this);
-        return fn.asApply(global, arguments);
+        return fn.apply(global, args);
       };
     }
     boundMethod.methodInfo = methodInfo;

--- a/src/avm2/trampoline.ts
+++ b/src/avm2/trampoline.ts
@@ -221,24 +221,21 @@ module Shumway.AVM2.Runtime {
      * Triggers the trampoline and executes it.
      */
     var trampoline: ITrampoline = <ITrampoline><any>function execute() {
-      debugLogTrampoline(description);
-      if (!target) {
-        trampoline.trigger();
-      }
-      return target.asApply(this, arguments);
+      release || debugLogTrampoline(description);
+      target || trampoline.trigger();
+      return target.apply(this, arguments);
     };
     /**
      * Just triggers the trampoline without executing it.
      */
     trampoline.trigger = function trigger() {
-      countTimeline("Triggering Trampoline");
-      if (!target) {
-        release || assert(!trait.methodInfo.isNative());
-        target = createFunction(trait.methodInfo, scope, false, false, false);
-        patch(patchTargets, target);
-        trait = scope = natives = patchTargets = null;
-        release || assert(target);
-      }
+      release || countTimeline("Triggering Trampoline");
+      release || assert(!target);
+      release || assert(!trait.methodInfo.isNative());
+      target = createFunction(trait.methodInfo, scope, false, false, false);
+      release || assert(target);
+      patch(patchTargets, target);
+      trait = scope = natives = patchTargets = null;
     };
     trampoline.isTrampoline = true;
     trampoline.patchTargets = patchTargets;
@@ -250,8 +247,9 @@ module Shumway.AVM2.Runtime {
   }
 
   function debugLogTrampoline(description: string) {
+    assert(!release);
     countTimeline("Executing Trampoline");
-    if (!release && Shumway.AVM2.Runtime.traceExecution.value >= 1) {
+    if (Shumway.AVM2.Runtime.traceExecution.value >= 1) {
       callWriter.writeLn("Trampoline: " + description);
       Shumway.AVM2.Runtime.traceExecution.value >= 3 && console.log("Trampolining");
     }


### PR DESCRIPTION
Because that allows JS engines to more readily detect and optimize usage of `Function.prototype.apply`.