### PR TITLE
Adds a way to trace call execution.

### DIFF
--- a/src/gfx/2d/2d.ts
+++ b/src/gfx/2d/2d.ts
@@ -18,7 +18,7 @@ module Shumway.GFX.Canvas2D {
 
   declare var registerScratchCanvas;
 
-  var writer = new IndentingWriter(false, dumpLine);
+  var writer = null; // new IndentingWriter(false, dumpLine);
 
   var MIN_CACHE_LEVELS = 5;
   var MAX_CACHE_LEVELS = 3;


### PR DESCRIPTION
This is very useful for debugging. To enable, set

```
var traceWriter = new IndentingWriter(false, dumpLine);
```

You will also need to make sure that the release flag is not set to true. At the moment we do this in utilities.ts and in viewerPlayer.js. Additionally, you will need to toggle the pref browser.dom.window.dump.enabled;true and naturally, run FF from the command line so you can get standard output.
 