### PR TITLE
Bug 1120562 - Work around rendering to a surface ignoring clipping, thus potentially overwriting another surface region

### DIFF
--- a/src/gfx/gl/glContext.ts
+++ b/src/gfx/gl/glContext.ts
@@ -190,7 +190,7 @@ module Shumway.GFX.WebGL {
     }
 
     public allocateSurfaceRegion(w: number, h: number, discardCache: boolean = true): WebGLSurfaceRegion {
-      return <WebGLSurfaceRegion>this._surfaceRegionAllocator.allocate(w, h);
+      return <WebGLSurfaceRegion>this._surfaceRegionAllocator.allocate(w, h, null);
     }
 
     /*

--- a/src/gfx/regionAllocator.ts
+++ b/src/gfx/regionAllocator.ts
@@ -332,7 +332,7 @@ module Shumway.GFX {
       /**
        * Allocates a 2D region.
        */
-      allocate(w: number, h: number): ISurfaceRegion;
+      allocate(w: number, h: number, excludeSurface: ISurface): ISurfaceRegion;
 
       /**
        * Frees the specified region.
@@ -363,9 +363,13 @@ module Shumway.GFX {
         this._surfaces.push(surface);
       }
 
-      allocate(w: number, h: number): ISurfaceRegion {
+      allocate(w: number, h: number, excludeSurface: ISurface): ISurfaceRegion {
         for (var i = 0; i < this._surfaces.length; i++) {
-          var region = this._surfaces[i].allocate(w, h);
+          var surface = this._surfaces[i];
+          if (surface === excludeSurface) {
+            continue;
+          }
+          var region = surface.allocate(w, h);
           if (region) {
             return region;
           }

--- a/src/gfx/renderables/renderables.ts
+++ b/src/gfx/renderables/renderables.ts
@@ -607,12 +607,13 @@ module Shumway.GFX {
      * like Flash ignores strokes when clipping so we can also ignore stroke paths when computing
      * the clip region.
      *
-     * If |paintStencil| is |true| then we most not create any alpha values, and also not paint any strokes.
+     * If |paintStencil| is |true| then we must not create any alpha values, and also not paint
+     * any strokes.
      */
     render(context: CanvasRenderingContext2D, ratio: number, cullBounds: Rectangle,
            paintClip: boolean = false, paintStencil: boolean = false): void
     {
-      var paintStencilStyle = '#FF4981';
+      var paintStencilStyle = release ? '#000000' : '#FF4981';
       context.fillStyle = context.strokeStyle = 'transparent';
 
       var paths = this._deserializePaths(this._pathData, context, ratio);
@@ -625,9 +626,13 @@ module Shumway.GFX {
                                               context['imageSmoothingEnabled'] =
                                               path.smoothImage;
         if (path.type === PathType.Fill) {
-          context.fillStyle = paintStencil ? paintStencilStyle : path.style;
-          paintClip ? context.clip(path.path, 'evenodd') : context.fill(path.path, 'evenodd');
-          context.fillStyle = 'transparent';
+          if (paintClip) {
+            context.clip(path.path, 'evenodd');
+          } else {
+            context.fillStyle = paintStencil ? paintStencilStyle : path.style;
+            context.fill(path.path, 'evenodd');
+            context.fillStyle = 'transparent';
+          }
         } else if (!paintClip && !paintStencil) {
           context.strokeStyle = path.style;
           var lineScaleMode = LineScaleMode.Normal;


### PR DESCRIPTION
Right now, we do this by forcing the mask's allocation to use a different surface. In cases where we otherwise would only need one surface, that's extremely wasteful, so we should avoid it.