### PR TITLE
Fix layering issue

### DIFF
--- a/src/gfx/easel.ts
+++ b/src/gfx/easel.ts
@@ -303,6 +303,7 @@ module Shumway.GFX {
       stageContainer.style.position = "absolute";
       stageContainer.style.width = "100%";
       stageContainer.style.height = "100%";
+      stageContainer.style.zIndex = "0";
       container.appendChild(stageContainer);
 
       // Create hud container, that lives on top of the stage.


### PR DESCRIPTION
Fixes the Shumway button not longer clickable cause video elements are stacked on top. This regressed in https://github.com/mozilla/shumway/pull/2071.