### PR TITLE
Fix ascent/descent math

### DIFF
--- a/src/TextContent.ts
+++ b/src/TextContent.ts
@@ -22,6 +22,7 @@ module Shumway {
   import DataBuffer = Shumway.ArrayUtilities.DataBuffer;
   import ColorUtilities = Shumway.ColorUtilities;
   import flash = Shumway.AVM2.AS.flash;
+  import altTieBreakRound = Shumway.NumberUtilities.altTieBreakRound;
 
   export enum TextContentFlags {
     None            = 0x0000,
@@ -459,8 +460,8 @@ module Shumway {
       } else {
         textRunData.writeUTF(font._fontFamily);
       }
-      textRunData.writeInt(font.ascent * size);
-      textRunData.writeInt(font.descent * size);
+      textRunData.writeInt(altTieBreakRound(font.ascent * size, true));
+      textRunData.writeInt(altTieBreakRound(font.descent * size, false));
       textRunData.writeInt(textFormat.leading === null ? font.leading * size : +textFormat.leading);
       // For embedded fonts, always set bold and italic to false. They're fully identified by name.
       var bold: boolean = false;

--- a/src/base/utilities.ts
+++ b/src/base/utilities.ts
@@ -1526,6 +1526,17 @@ module Shumway {
       return Math.round(value);
     }
 
+    /**
+     * Rounds *.5 up on even occurrences, down on odd occurrences.
+     * See https://en.wikipedia.org/wiki/Rounding#Alternating_tie-breaking for details.
+     */
+    export function altTieBreakRound(value: number, even: boolean): number {
+      if (Math.abs(value % 1) === 0.5 && !even) {
+        return value | 0;
+      }
+      return Math.round(value);
+    }
+
     export function epsilonEquals(value: number, other: number): boolean {
       return Math.abs(value - other) < 0.0000001;
     }


### PR DESCRIPTION
This fixes text being cut off in the Facebook video player.