### PR TITLE
Simple heuristics to reject loading of crossdomain SWFs.

### DIFF
--- a/src/flash/system/Security.ts
+++ b/src/flash/system/Security.ts
@@ -81,9 +81,17 @@ module Shumway.AVM2.AS.flash.system {
     static allowDomain(): void {
       somewhatImplemented("public flash.system.Security::static allowDomain [\"" +
         Array.prototype.join.call(arguments, "\", \"") + "\"]");
+      var whitelist: ICrossDomainSWFLoadingWhitelist = Shumway.AVM2.Runtime.AVM2.instance.globals['Shumway.Player.Utils'];
+      for (var i = 0; i < arguments.length; i++) {
+        whitelist.addToSWFLoadingWhitelist(asCoerceString(arguments[i]), false);
+      }
     }
     static allowInsecureDomain(): void {
       somewhatImplemented("public flash.system.Security::static allowInsecureDomain");
+      var whitelist: ICrossDomainSWFLoadingWhitelist = Shumway.AVM2.Runtime.AVM2.instance.globals['Shumway.Player.Utils'];
+      for (var i = 0; i < arguments.length; i++) {
+        whitelist.addToSWFLoadingWhitelist(asCoerceString(arguments[i]), true);
+      }
     }
     static loadPolicyFile(url: string): void {
       url = asCoerceString(url);
@@ -102,5 +110,10 @@ module Shumway.AVM2.AS.flash.system {
       notImplemented("public flash.system.Security::static duplicateSandboxBridgeOutputArgument"); return;
     }
     
+  }
+
+  export interface ICrossDomainSWFLoadingWhitelist {
+    addToSWFLoadingWhitelist(domain: string, insecure: boolean);
+    checkDomainForSWFLoading(domain: string): boolean;
   }
 }

--- a/src/shell/domstubs.ts
+++ b/src/shell/domstubs.ts
@@ -97,8 +97,38 @@ this.Image = function () {};
 this.Image.prototype = {
 };
 
-this.URL = function () {};
+this.URL = function (url, baseURL) {
+  if (url.indexOf('://') >= 0 || baseURL === url) {
+    this._setURL(url);
+    return;
+  }
+
+  var base = baseURL || '';
+  var base = base.lastIndexOf('/') >= 0 ? base.substring(0, base.lastIndexOf('/') + 1) : '';
+  if (url.indexOf('/') === 0) {
+    var m = /^[^:]+:\/\/[^\/]+/.exec(base);
+    if (m) base = m[0];
+  }
+  this._setURL(base + url);
+};
 this.URL.prototype = {
+  _setURL: function (url) {
+    this.href = url;
+    // Simple parsing to extract protocol, hostname and port.
+    var m = /^(\w+:)\/\/([^:/]+)(:([0-9]+))?/.exec(url.toLowerCase());
+    if (m) {
+      this.protocol = m[1];
+      this.hostname = m[2];
+      this.port = m[4] || '';
+    } else {
+      this.protocol = 'file:';
+      this.hostname = '';
+      this.port = '';
+    }
+  },
+  toString: function () {
+    return this.href;
+  }
 };
 this.URL.createObjectURL = function createObjectURL() {
   return "";

--- a/src/shell/playerservices.ts
+++ b/src/shell/playerservices.ts
@@ -83,21 +83,7 @@ module Shumway.Shell
       return url;
     },
     resolveUrl: function (url) {
-      if (url.indexOf('://') >= 0) {
-        return url;
-      }
-
-      var base = shellFileLoadingService.baseUrl || '';
-      if (base === url) {
-        return url;
-      }
-
-      base = base.lastIndexOf('/') >= 0 ? base.substring(0, base.lastIndexOf('/') + 1) : '';
-      if (url.indexOf('/') === 0) {
-        var m = /^[^:]+:\/\/[^\/]+/.exec(base);
-        if (m) base = m[0];
-      }
-      return base + url;
+      return new (<any>URL)(url, shellFileLoadingService.baseUrl).href;
     },
     navigateTo: function (url, target) {
     }

--- a/web/iframe/compatibility.js
+++ b/web/iframe/compatibility.js
@@ -43,7 +43,7 @@
   function newURL(url, baseURL) {
     // Just enough to make viewer working.
     if (!baseURL || url.indexOf('://') >= 0) {
-      this.href = url;
+      this._setURL(url);
       return;
     }
 
@@ -55,9 +55,19 @@
         base = m[0];
       }
     }
-    this.href = base + url;
+    this._setURL(base + url);
   }
   newURL.prototype = {
+    _setURL: function (url) {
+      this.href = url;
+      // Simple parsing to extract protocol, hostname and port.
+      var m = /^(\w+:)\/\/([^:/]+)(:([0-9]+))?/.exec(url.toLowerCase());
+      if (m) {
+        this.protocol = m[1];
+        this.hostname = m[2];
+        this.port = m[4] || '';
+      }
+    },
     toString: function () {
       return this.href;
     }


### PR DESCRIPTION
Basically it's tracking all allowDomain calls and adds them to the whitelist. Before loading a new SWF Loader.load checks if the remote SWF allowed by this whitelist.

/cc @tschneidereit 