### PR TITLE
Escape string

### DIFF
--- a/src/avm2/compiler/c4/ast.ts
+++ b/src/avm2/compiler/c4/ast.ts
@@ -84,8 +84,7 @@ module Shumway.AVM2.Compiler.AST {
   var escapeStringCache = Object.create(null);
 
   export function escapeString(str: string) {
-    var result, i, len, ch, original = str;
-    result = escapeStringCache[original];
+    var result = escapeStringCache[str];
     if (result) {
       return result;
     }
@@ -93,11 +92,13 @@ module Shumway.AVM2.Compiler.AST {
       escapeStringCache = Object.create(null);
       escapeStringCacheCount = 0;
     }
-    result = '';
+    result = '"';
 
-    for (i = 0, len = str.length; i < len; ++i) {
-      ch = str[i];
-      if ('\\\n\r\u2028\u2029'.indexOf(ch) >= 0) {
+    for (var i = 0, len = str.length; i < len; ++i) {
+      var ch = str[i];
+      if (ch === '"') {
+        result += '\\';
+      } else if ('\\\n\r\u2028\u2029'.indexOf(ch) >= 0) {
         result += escapeDisallowedCharacter(ch);
         continue;
       } else if (!(ch >= ' ' && ch <= '~')) {
@@ -107,19 +108,8 @@ module Shumway.AVM2.Compiler.AST {
       result += ch;
     }
 
-    str = result;
-    result = '"';
-
-    for (i = 0, len = str.length; i < len; ++i) {
-      ch = str[i];
-      if (ch === '"') {
-        result += '\\';
-      }
-      result += ch;
-    }
-
     result += '"';
-    escapeStringCache[original] = result;
+    escapeStringCache[str] = result;
     escapeStringCacheCount ++;
     return result;
   }

--- a/src/avm2/compiler/c4/ast.ts
+++ b/src/avm2/compiler/c4/ast.ts
@@ -25,7 +25,6 @@ module Shumway.AVM2.Compiler.AST {
 
   var hexadecimal = false;
   var renumber = false;
-  var quotes = "double";
 
   function escapeAllowedCharacter(ch, next) {
     var code = ch.charCodeAt(0), hex = code.toString(16), result = '\\';
@@ -85,7 +84,7 @@ module Shumway.AVM2.Compiler.AST {
   var escapeStringCache = Object.create(null);
 
   export function escapeString(str: string) {
-    var result, i, len, ch, singleQuotes = 0, doubleQuotes = 0, single, original = str;
+    var result, i, len, ch, original = str;
     result = escapeStringCache[original];
     if (result) {
       return result;
@@ -98,11 +97,7 @@ module Shumway.AVM2.Compiler.AST {
 
     for (i = 0, len = str.length; i < len; ++i) {
       ch = str[i];
-      if (ch === '\'') {
-        ++singleQuotes;
-      } else if (ch === '"') {
-        ++doubleQuotes;
-      } else if ('\\\n\r\u2028\u2029'.indexOf(ch) >= 0) {
+      if ('\\\n\r\u2028\u2029'.indexOf(ch) >= 0) {
         result += escapeDisallowedCharacter(ch);
         continue;
       } else if (!(ch >= ' ' && ch <= '~')) {
@@ -112,19 +107,18 @@ module Shumway.AVM2.Compiler.AST {
       result += ch;
     }
 
-    single = !(quotes === 'double' || (quotes === 'auto' && doubleQuotes < singleQuotes));
     str = result;
-    result = single ? '\'' : '"';
+    result = '"';
 
     for (i = 0, len = str.length; i < len; ++i) {
       ch = str[i];
-      if ((ch === '\'' && single) || (ch === '"' && !single)) {
+      if (ch === '"') {
         result += '\\';
       }
       result += ch;
     }
 
-    result += (single ? '\'' : '"');
+    result += '"';
     escapeStringCache[original] = result;
     escapeStringCacheCount ++;
     return result;

--- a/src/avm2/compiler/c4/ast.ts
+++ b/src/avm2/compiler/c4/ast.ts
@@ -29,16 +29,6 @@ module Shumway.AVM2.Compiler.AST {
   var renumber = false;
   var quotes = "double";
 
-  function stringToArray(str) {
-    var length = str.length,
-      result = [],
-      i;
-    for (i = 0; i < length; ++i) {
-      result[i] = str.charAt(i);
-    }
-    return result;
-  }
-
   function escapeAllowedCharacter(ch, next) {
     var code = ch.charCodeAt(0), hex = code.toString(16), result = '\\';
 
@@ -96,7 +86,7 @@ module Shumway.AVM2.Compiler.AST {
   var escapeStringCacheCount = 0;
   var escapeStringCache = Object.create(null);
 
-  export function escapeString(str) {
+  export function escapeString(str: string) {
     var result, i, len, ch, singleQuotes = 0, doubleQuotes = 0, single, original = str;
     result = escapeStringCache[original];
     if (result) {
@@ -107,10 +97,6 @@ module Shumway.AVM2.Compiler.AST {
       escapeStringCacheCount = 0;
     }
     result = '';
-
-    if (typeof str[0] === 'undefined') {
-      str = stringToArray(str);
-    }
 
     for (i = 0, len = str.length; i < len; ++i) {
       ch = str[i];
@@ -133,10 +119,6 @@ module Shumway.AVM2.Compiler.AST {
     single = !(quotes === 'double' || (quotes === 'auto' && doubleQuotes < singleQuotes));
     str = result;
     result = single ? '\'' : '"';
-
-    if (typeof str[0] === 'undefined') {
-      str = stringToArray(str);
-    }
 
     for (i = 0, len = str.length; i < len; ++i) {
       ch = str[i];

--- a/src/avm2/compiler/c4/ast.ts
+++ b/src/avm2/compiler/c4/ast.ts
@@ -27,57 +27,43 @@ module Shumway.AVM2.Compiler.AST {
   var renumber = false;
 
   function escapeAllowedCharacter(ch, next) {
-    var code = ch.charCodeAt(0), hex = code.toString(16), result = '\\';
-
     switch (ch) {
       case '\b':
-        result += 'b';
-        break;
+        return '\\b';
       case '\f':
-        result += 'f';
-        break;
+        return '\\f';
       case '\t':
-        result += 't';
-        break;
+        return '\\t';
       default:
+        var code = ch.charCodeAt(0), hex = code.toString(16), result;
         if (code > 0xff) {
-          result += 'u' + '0000'.slice(hex.length) + hex;
+          result = '\\u' + '0000'.slice(hex.length) + hex;
         } else if (ch === '\u0000' && '0123456789'.indexOf(next) < 0) {
-          result += '0';
+          result = '\\0';
         } else if (ch === '\x0B') { // '\v'
-          result += 'x0B';
+          result = '\\x0B';
         } else {
-          result += 'x' + '00'.slice(hex.length) + hex;
+          result = '\\x' + '00'.slice(hex.length) + hex;
         }
-        break;
+        return result;
     }
-
-    return result;
   }
 
   function escapeDisallowedCharacter(ch) {
-    var result = '\\';
     switch (ch) {
       case '\\':
-        result += '\\';
-        break;
+        return '\\\\';
       case '\n':
-        result += 'n';
-        break;
+        return '\\n';
       case '\r':
-        result += 'r';
-        break;
+        return '\\r';
       case '\u2028':
-        result += 'u2028';
-        break;
+        return '\\u2028';
       case '\u2029':
-        result += 'u2029';
-        break;
+        return '\\u2029';
       default:
         throw new Error('Incorrectly classified character');
     }
-
-    return result;
   }
 
   var escapeStringCacheCount = 0;

--- a/src/avm2/compiler/c4/ast.ts
+++ b/src/avm2/compiler/c4/ast.ts
@@ -23,7 +23,6 @@ module Shumway.AVM2.Compiler.AST {
   import assertUnreachable = Shumway.Debug.assertUnreachable;
   // The top part of this file is copied from escodegen.
 
-  var json = false;
   var escapeless = false;
   var hexadecimal = false;
   var renumber = false;
@@ -43,7 +42,7 @@ module Shumway.AVM2.Compiler.AST {
         result += 't';
         break;
       default:
-        if (json || code > 0xff) {
+        if (code > 0xff) {
           result += 'u' + '0000'.slice(hex.length) + hex;
         } else if (ch === '\u0000' && '0123456789'.indexOf(next) < 0) {
           result += '0';
@@ -104,12 +103,10 @@ module Shumway.AVM2.Compiler.AST {
         ++singleQuotes;
       } else if (ch === '"') {
         ++doubleQuotes;
-      } else if (ch === '/' && json) {
-        result += '\\';
       } else if ('\\\n\r\u2028\u2029'.indexOf(ch) >= 0) {
         result += escapeDisallowedCharacter(ch);
         continue;
-      } else if ((json && ch < ' ') || !(json || escapeless || (ch >= ' ' && ch <= '~'))) {
+      } else if (!(escapeless || (ch >= ' ' && ch <= '~'))) {
         result += escapeAllowedCharacter(ch, str[i + 1]);
         continue;
       }
@@ -148,7 +145,7 @@ module Shumway.AVM2.Compiler.AST {
     }
 
     if (value === 1 / 0) {
-      return json ? 'null' : renumber ? '1e400' : '1e+400';
+      return renumber ? '1e400' : '1e+400';
     }
 
     result = generateNumberCache[value];
@@ -167,7 +164,7 @@ module Shumway.AVM2.Compiler.AST {
     }
 
     point = result.indexOf('.');
-    if (!json && result.charAt(0) === '0' && point === 1) {
+    if (result.charAt(0) === '0' && point === 1) {
       point = 0;
       result = result.slice(1);
     }

--- a/src/avm2/compiler/c4/ast.ts
+++ b/src/avm2/compiler/c4/ast.ts
@@ -23,7 +23,6 @@ module Shumway.AVM2.Compiler.AST {
   import assertUnreachable = Shumway.Debug.assertUnreachable;
   // The top part of this file is copied from escodegen.
 
-  var escapeless = false;
   var hexadecimal = false;
   var renumber = false;
   var quotes = "double";
@@ -106,7 +105,7 @@ module Shumway.AVM2.Compiler.AST {
       } else if ('\\\n\r\u2028\u2029'.indexOf(ch) >= 0) {
         result += escapeDisallowedCharacter(ch);
         continue;
-      } else if (!(escapeless || (ch >= ' ' && ch <= '~'))) {
+      } else if (!(ch >= ' ' && ch <= '~')) {
         result += escapeAllowedCharacter(ch, str[i + 1]);
         continue;
       }


### PR DESCRIPTION
[This ad](http://areweflashyet.com/swfs/2b1c3484cfd1fded9366fb6394ec3a736512144ac4a5650213eab80b9342b75fcd9c73835b9aa3d5e89fe6ead44bd9d5b75861e475640900c404d81f33788845.swf) causes `Shumway.AVM2.Compiler.AST.escapeString` to be called with a 1.6 MB XML string. This exposes the fact that `escapeString` is very inefficient, primarily because it does the escaping in two passes, creating two new strings. It does this in order to decide whether to use single or double quotes in the final string. Shumway doesn't need this flexibility, and so it can easily be reduced to a single pass.