### PR TITLE
Bug 1146593 - Checking for hang in runFrameScripts.

### DIFF
--- a/examples/inspector/js/inspectorDebugging.js
+++ b/examples/inspector/js/inspectorDebugging.js
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+Shumway.AVM2.AS.scriptsTimeout.value = 0;
 Shumway.AVM1.avm1TimeoutDisabled.value = true;
 
 // Examples of the commands to control the AVM1 debugger

--- a/src/flash/display/MovieClip.ts
+++ b/src/flash/display/MovieClip.ts
@@ -188,6 +188,7 @@ module Shumway.AVM2.AS.flash.display {
     static instanceSymbols: string [] = null; // ["currentLabels"];
 
     static runFrameScripts() {
+      var start = Date.now();
       enterTimeline("MovieClip.executeFrame");
       var queue: MovieClip[] = MovieClip._callQueue;
       MovieClip._callQueue = [];
@@ -219,6 +220,16 @@ module Shumway.AVM2.AS.flash.display {
         }
       }
       leaveTimeline();
+
+      // Running individual scripts might not take long time, however if lots of
+      // objects present the total execution time might be unacceptable.
+      var duration = Date.now() - start;
+      if (scriptsTimeout.value > 0 && duration > scriptsTimeout.value) {
+        console.warn('runFrameScripts timeout -- stopping scripts execution');
+        var manager: flash.system.IScriptsExecutionManager =
+          Shumway.AVM2.Runtime.AVM2.instance.globals['Shumway.Player.Utils'];
+        manager.stopScripts();
+      }
     }
 
     constructor () {

--- a/src/flash/options.ts
+++ b/src/flash/options.ts
@@ -37,4 +37,8 @@ module Shumway.AVM2.AS {
   export var flvOption = flashOptions.register (
     new Shumway.Options.Option(null, "FLV support.", "string", "unsupported", "Defines how to deal with FLV streams.")
   );
+
+  export var scriptsTimeout = flashOptions.register (
+    new Shumway.Options.Option("", "Scripts timeout", "number", 1000, "Specifies script execution timeout before hang is declared (in ms).")
+  );
 }

--- a/src/flash/system/FSCommand.ts
+++ b/src/flash/system/FSCommand.ts
@@ -61,4 +61,8 @@ module Shumway.AVM2.AS.flash.system {
   export interface IFSCommandListener {
     executeFSCommand(command: string, args: string);
   }
+
+  export interface IScriptsExecutionManager {
+    stopScripts();
+  }
 }

--- a/src/player/player.ts
+++ b/src/player/player.ts
@@ -41,6 +41,7 @@ module Shumway.Player {
   import IBitmapDataSerializer = flash.display.IBitmapDataSerializer;
   import IAssetResolver = Timeline.IAssetResolver;
   import IFSCommandListener = flash.system.IFSCommandListener;
+  import IScriptsExecutionManager = flash.system.IScriptsExecutionManager;
   import IVideoElementService = flash.net.IVideoElementService;
   import IRootElementService = flash.display.IRootElementService;
   import ICrossDomainSWFLoadingWhitelist = flash.system.ICrossDomainSWFLoadingWhitelist;
@@ -225,7 +226,8 @@ module Shumway.Player {
    * synchronizes the frame tree with the display list.
    */
   export class Player implements IBitmapDataSerializer, IFSCommandListener, IVideoElementService,
-                                 IAssetResolver, IRootElementService, ICrossDomainSWFLoadingWhitelist {
+                                 IAssetResolver, IRootElementService, ICrossDomainSWFLoadingWhitelist,
+                                 IScriptsExecutionManager {
     _stage: flash.display.Stage;
     private _loader: flash.display.Loader;
     private _loaderInfo: flash.display.LoaderInfo;
@@ -467,12 +469,17 @@ module Shumway.Player {
     public executeFSCommand(command: string, args: string) {
       switch (command) {
         case 'quit':
-          this._leaveEventLoop();
+          this.stopScripts();
           break;
         default:
           somewhatImplemented('FSCommand ' + command);
       }
       this._gfxService.fscommand(command, args);
+    }
+
+    public stopScripts() {
+      // TODO stop also timers
+      this._leaveEventLoop();
     }
 
     public requestRendering(): void {


### PR DESCRIPTION
gotoAndPlay is really expensive right now and http://areweflashyet.com/swfs/1e902e33c40af1d1f6296bde21379600b35576a027cc888f78c5afe792db04e68b6e57671704aeee2814ee0e061608d386021a7985fb8e17a041e1658a39e3f7.swf has lots of objects calling it.

Detecting hang in runFrameScripts.

see https://bugzilla.mozilla.org/show_bug.cgi?id=1146593

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2131)
<!-- Reviewable:end -->
