### PR TITLE
Bug 1143487 - Disabling external interface if processExternalCommand is not specified.

### DIFF
--- a/web/iframe/viewerPlayer.js
+++ b/web/iframe/viewerPlayer.js
@@ -38,7 +38,7 @@ var iframeExternalInterface = {
   processExternalCommand: null,
 
   get enabled() {
-    return true;
+    return !!this.processExternalCommand;
   },
 
   initJS: function (callback) {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1143487