### PR TITLE
Bug 1136470 - Protect from double components registration.

### DIFF
--- a/extension/firefox/content/ShumwayBootstrapUtils.jsm
+++ b/extension/firefox/content/ShumwayBootstrapUtils.jsm
@@ -99,6 +99,10 @@ var ShumwayBootstrapUtils = {
   isRegistered: false,
 
   register: function () {
+    if (this.isRegistered) {
+      return;
+    }
+
     this.isRegistered = true;
 
     // Register the components.
@@ -122,6 +126,10 @@ var ShumwayBootstrapUtils = {
   },
 
   unregister: function () {
+    if (!this.isRegistered) {
+      return;
+    }
+
     this.isRegistered = false;
 
     // Remove the contract/component.


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1136470