### PR TITLE
Only rig timers and Math.random in a special `deterministic` mode in the shell

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -140,7 +140,7 @@ module.exports = function(grunt) {
       test_avm2_shumway: {
         maxBuffer: Infinity,
         cmd: 'mkdir -p build/test/avm2; ' +
-             'cat test/avm2/shumway.txt | xargs utils/jsshell/js build/ts/shell.js -x --printABCFileName > build/test/test_avm2_shumway.run; ' +
+             'cat test/avm2/shumway.txt | xargs utils/jsshell/js build/ts/shell.js -x -det --printABCFileName > build/test/test_avm2_shumway.run; ' +
              // Run all tests from shumway.txt each in many instances of Tamarin and save the output in |test/avm2/shumway.baseline|.
              // Between each run, emit the test name as "::: test :::" so it's easy to identify where things go wrong.
              'rm test/test_avm2_shumway.baseline; cat test/avm2/shumway.txt | grep -v @ | xargs -L 1 -I \'{}\' sh -c \'echo "::: {} :::" >> test/test_avm2_shumway.baseline; utils/tamarin-redux/bin/shell/avmshell {} >> test/test_avm2_shumway.baseline;\'; ' +
@@ -151,14 +151,14 @@ module.exports = function(grunt) {
       test_avm2_acceptance: {
         maxBuffer: Infinity,
         cmd: 'mkdir -p build/test; ' +
-             'utils/jsshell/js build/ts/shell.js -x -v test/avm2/acceptance.json | tee build/test/test_avm2_acceptance_stdout.run | node test/avm2/count_totals.js | tee build/test/test_avm2_acceptance.run && ' +
+             'utils/jsshell/js build/ts/shell.js -x -det -v test/avm2/acceptance.json | tee build/test/test_avm2_acceptance_stdout.run | node test/avm2/count_totals.js | tee build/test/test_avm2_acceptance.run && ' +
              'diff build/test/test_avm2_acceptance.run test/test_avm2_acceptance.baseline'
       },
       // Runs the pypy tests and tests against the current baseline. If you get more tests to pass, update the baseline.
       test_avm2_pypy: {
         maxBuffer: Infinity,
         cmd: 'mkdir -p build/test; ' +
-             'find -L test/avm2/pypy -name "*.abc" | xargs -I {} utils/jsshell/js build/ts/shell.js -x -v {} | tee build/test/test_avm2_pypy.run &&' +
+             'find -L test/avm2/pypy -name "*.abc" | xargs -I {} utils/jsshell/js build/ts/shell.js -x -det -v {} | tee build/test/test_avm2_pypy.run &&' +
              'diff build/test/test_avm2_pypy.run test/test_avm2_pypy.baseline'
       },
       // Runs archive SWFs and tests against the current baseline. If you get more tests to pass, update the baseline.
@@ -167,14 +167,14 @@ module.exports = function(grunt) {
       test_arch: {
         maxBuffer: Infinity,
         cmd: 'mkdir -p build/test/; ' +
-             'find -L test/arch/swfs -name "*.swf" | parallel --gnu -X -N1 utils/jsshell/js build/ts/shell.js -x -fc 10 {} | tee build/test_arch.run;' +
+             'find -L test/arch/swfs -name "*.swf" | parallel --gnu -X -N1 utils/jsshell/js build/ts/shell.js -x -det -fc 10 {} | tee build/test_arch.run;' +
              'echo "Output saved to build/test_arch.run, at some point create a baseline and stick to it."'
           // 'diff build/test/arch/arch.run test/arch/arch.baseline'
       },
       // Runs SWFs and tests against the current baseline. If you get more tests to pass, update the baseline.
       test_swf: {
         maxBuffer: Infinity,
-        cmd: 'find -L test/swf -name "*.swf" | parallel -k --gnu -X -N1 utils/jsshell/js build/ts/shell.js -x -fc 10 {} | LC_ALL=C sort > build/test/test_swf.run && ' +
+        cmd: 'find -L test/swf -name "*.swf" | parallel -k --gnu -X -N1 utils/jsshell/js build/ts/shell.js -x -det -fc 10 {} | LC_ALL=C sort > build/test/test_swf.run && ' +
              'diff build/test/test_swf.run test/test_swf.baseline'
       },
       // Runs SWF trace tests.
@@ -191,7 +191,7 @@ module.exports = function(grunt) {
       test_avm2_ats: {
         maxBuffer: Infinity,
         cmd: 'mkdir -p build/test; ' +
-             'cat test/ats/test_swf_avm2.txt | parallel -k --gnu -X -N50 utils/jsshell/js build/ts/shell.js -x -fc 10 {} > build/test/test_avm2_ats.run; ' +
+             'cat test/ats/test_swf_avm2.txt | parallel -k --gnu -X -N50 utils/jsshell/js build/ts/shell.js -x -det -fc 10 {} > build/test/test_avm2_ats.run; ' +
              'if [ ! -f "test/ats/test_avm2_ats.baseline" ]; then echo "Creating Baseline"; cp build/test/test_avm2_ats.run test/test_avm2_ats.baseline; fi;' +
              'diff build/test/test_avm2_ats.run test/test_avm2_ats.baseline;'
       },
@@ -208,12 +208,12 @@ module.exports = function(grunt) {
       },
       test_swf_avm2_all: {
         maxBuffer: Infinity,
-        cmd: 'mongo ats --eval \'db.swfs.find({"parse_result.uses_avm1": false}).forEach(function (x) { print("test/ats/swfs/" + x.file); })\' | parallel -k --gnu -X -N10 utils/jsshell/js build/ts/shell.js -x -fc 10 {} | tee test/ats/test_swf_avm2_all.run;'
+        cmd: 'mongo ats --eval \'db.swfs.find({"parse_result.uses_avm1": false}).forEach(function (x) { print("test/ats/swfs/" + x.file); })\' | parallel -k --gnu -X -N10 utils/jsshell/js build/ts/shell.js -x -det -fc 10 {} | tee test/ats/test_swf_avm2_all.run;'
       },
       test_mock: {
         maxBuffer: Infinity,
         cmd: 'mkdir -p build/test;' +
-             'utils/jsshell/js build/ts/shell.js -x test/mock/jwplayer.js examples/jwplayer/jwplayer.flash.swf -fc 10 > build/test/test_mock.run;' +
+             'utils/jsshell/js build/ts/shell.js -x -det test/mock/jwplayer.js examples/jwplayer/jwplayer.flash.swf -fc 10 > build/test/test_mock.run;' +
              'diff build/test/test_mock.run test/test_mock.baseline;'
       },
       bench_avm2: {
@@ -222,7 +222,7 @@ module.exports = function(grunt) {
       },
       perf_avm2_acceptance: {
         maxBuffer: Infinity,
-        cmd: 'utils/jsshell/js build/ts/shell.js -x -r --porcelain test/avm2/acceptance.json > /dev/null 2>&1'
+        cmd: 'utils/jsshell/js build/ts/shell.js -x -det -r --porcelain test/avm2/acceptance.json > /dev/null 2>&1'
       },
       // Parses all ABCs in the acceptance suite. This is useful to run if you've made changes to the parser.
       trace_avm2_acceptance_parse: {

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -190,6 +190,7 @@ module Shumway.Shell {
   var verboseOption: Option;
   var profileOption: Option;
   var releaseOption: Option;
+  var deterministicOption: Option;
   var executeOption: Option;
   var freshSecurityDomainOption: Option;
   var printABCFileNameOption: Option;
@@ -219,6 +220,7 @@ module Shumway.Shell {
     verboseOption = shellOptions.register(new Option("v", "verbose", "boolean", false, "Verbose"));
     profileOption = shellOptions.register(new Option("o", "profile", "boolean", false, "Profile"));
     releaseOption = shellOptions.register(new Option("r", "release", "boolean", false, "Release mode"));
+    deterministicOption = shellOptions.register(new Option("det", "deterministic", "boolean", false, "Deterministic execution, with rigged timers and random generator"));
     if (!disableBundleSelection) {
       usePlayerClosureBundleOption = shellOptions.register(new Option('b', "closure-bundle", "boolean", false, "Use bundled and closure compiled source file for the player."));
       usePlayerBundleOption = shellOptions.register(new Option('', "bundle", "boolean", false, "Use bundled source file for the player."));
@@ -415,8 +417,10 @@ module Shumway.Shell {
     }
     function runSWF(file: any) {
       microTaskQueue.clear();
-      Shumway.Random.reset();
-      Shumway.Shell.installTimeWarper();
+      if (deterministicOption) {
+        Shumway.Random.reset();
+        Shumway.Shell.installTimeWarper();
+      }
 
       var sec = createSecurityDomain(builtinABCPath, null, null);
       var player = new Shumway.Player.Player(sec, new ShellGFXServer());


### PR DESCRIPTION
Because it interferes with the normal operation of benchmarking SWFs.

@mbebenita, this needs a close look, because I probably forgot places to guard with this flag.