### PR TITLE
Fix property lookup bug that breaks lots of Haxe-compiled content

### DIFF
--- a/src/avm2/abc/lazy.ts
+++ b/src/avm2/abc/lazy.ts
@@ -1585,9 +1585,8 @@ module Shumway.AVMX {
      */
     public getNamespace(i: number): Namespace {
       if (i < 0 || i >= this._namespaceOffsets.length) {
-        this.applicationDomain.sec.throwError("VerifierError",
-                                                         Errors.CpoolIndexRangeError, i,
-                                                         this._namespaceOffsets.length);
+        this.applicationDomain.sec.throwError("VerifierError", Errors.CpoolIndexRangeError, i,
+                                              this._namespaceOffsets.length);
       }
       if (i === 0) {
         return null;
@@ -1624,7 +1623,7 @@ module Shumway.AVMX {
           break;
         default:
           this.applicationDomain.sec.throwError("VerifierError",
-                                                           Errors.CpoolEntryWrongTypeError, i);
+                                                Errors.CpoolEntryWrongTypeError, i);
       }
       if (uri && type !== NamespaceType.Private) {
         // TODO: deal with API versions here. Those are suffixed to the uri. We used to
@@ -1644,9 +1643,8 @@ module Shumway.AVMX {
      */
     public getNamespaceSet(i: number): Namespace [] {
       if (i < 0 || i >= this._namespaceSets.length) {
-        this.applicationDomain.sec.throwError("VerifierError",
-                                                         Errors.CpoolIndexRangeError, i,
-                                                         this._namespaceSets.length);
+        this.applicationDomain.sec.throwError("VerifierError", Errors.CpoolIndexRangeError, i,
+                                              this._namespaceSets.length);
       }
       if (i === 0) {
         return null;

--- a/src/avm2/int.ts
+++ b/src/avm2/int.ts
@@ -41,6 +41,9 @@ module Shumway.AVMX {
 
     public topScope(): Scope {
       if (!this.scopes) {
+        if (this.stack.length === 0) {
+          return this.parent;
+        }
         this.scopes = [];
       }
       var parent = this.parent;

--- a/src/avm2/run.ts
+++ b/src/avm2/run.ts
@@ -1214,7 +1214,11 @@ module Shumway.AVMX {
       } else {
         var rootClassTraits = this.AXClass.classInfo.instanceInfo.runtimeTraits;
         release || assert(rootClassTraits);
-        classTraits = classInfo.traits.resolveRuntimeTraits(rootClassTraits, null, scope);
+        // Class traits don't capture the class' scope. This is relevant because it allows
+        // referring to global names that would be shadowed if the class scope were active.
+        // Haxe's stdlib uses just such constructs, e.g. Std.parseFloat calls the global
+        // parseFloat.
+        classTraits = classInfo.traits.resolveRuntimeTraits(rootClassTraits, null, scope.parent);
       }
       classInfo.runtimeTraits = classTraits;
       applyTraits(axClass, classTraits);


### PR DESCRIPTION
This fixes [swf archive entry 1692](http://swf.codeazur.com.br/?class=&method=&width=&height=&tag=#9af86a33262baadce2ad23bb2bbb053e5e9624dcee4d77620094e435d5377114).

@mbebenita, this doesn't regress anything in our test suites (amazingly, it also doesn't make a single additional test pass), but I'd appreciate a sanity-check of my reasoning. In particular, I'm not at all sure if using `scope.parent` for class traits is the right thing or if some other scope should be used.