### PR TITLE
Fix silly bug preventing the `deterministic` shell option from ever being false

### DIFF
--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -417,7 +417,7 @@ module Shumway.Shell {
     }
     function runSWF(file: any) {
       microTaskQueue.clear();
-      if (deterministicOption) {
+      if (deterministicOption.value) {
         Shumway.Random.reset();
         Shumway.Shell.installTimeWarper();
       }


### PR DESCRIPTION
r=me