### PR TITLE
Reduces AVM1 execution memory consumption.

### DIFF
--- a/src/avm1/context.ts
+++ b/src/avm1/context.ts
@@ -21,9 +21,13 @@ module Shumway.AVM1 {
   import AVM1Globals = Lib.AVM1Globals;
 
   export class AVM1ActionsData {
-    public ir; // will cache compiled representation
+    public ir: AnalyzerResults;
+    public compiled: Function;
+
     constructor(public bytes: Uint8Array, public id: string, public parent: AVM1ActionsData = null) {
       release || assert(bytes instanceof Uint8Array);
+      this.ir = null;
+      this.compiled = null;
     }
   }
 
@@ -201,7 +205,7 @@ module Shumway.AVM1 {
       }
     }
 
-    public getStaticState(cls: typeof AVM1Object): any {
+    public getStaticState(cls): any {
       var state = this.staticStates.get(cls);
       if (!state) {
         state = Object.create(null);

--- a/src/avm1/options.ts
+++ b/src/avm1/options.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015 Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+module Shumway.AVM1 {
+  import Option = Shumway.Options.Option;
+  import OptionSet = Shumway.Options.OptionSet;
+
+  import shumwayOptions = Shumway.Settings.shumwayOptions;
+
+  var avm1Options = shumwayOptions.register(new OptionSet("AVM1"));
+  export var avm1TraceEnabled = avm1Options.register(new Option("t1", "traceAvm1", "boolean", false, "trace AVM1 execution"));
+  export var avm1ErrorsEnabled = avm1Options.register(new Option("e1", "errorsAvm1", "boolean", false, "fail on AVM1 warnings and errors"));
+  export var avm1TimeoutDisabled = avm1Options.register(new Option("ha1", "nohangAvm1", "boolean", false, "disable fail on AVM1 hang"));
+  export var avm1CompilerEnabled = avm1Options.register(new Option("ca1", "compileAvm1", "boolean", true, "compiles AVM1 code"));
+  export var avm1DebuggerEnabled = avm1Options.register(new Option("da1", "debugAvm1", "boolean", false, "allows AVM1 code debugging"));
+  export var avm1WellknownActionsCompilationsEnabled = avm1Options.register(new Option("cw1", "wellknownAvm1", "boolean", true, "Replaces well-known actions patterns instead of compilation"));
+}

--- a/src/avm1/references.ts
+++ b/src/avm1/references.ts
@@ -17,6 +17,7 @@
 /// <reference path='../../build/ts/avm2.d.ts' />
 /// <reference path='flash.d.ts' />
 
+///<reference path='options.ts' />
 ///<reference path='stream.ts' />
 ///<reference path='parser.ts' />
 ///<reference path='analyze.ts' />


### PR DESCRIPTION
Precompiles some ActionBlocks.
Refactors AVM1 ActionTracer.
Holding AVM1 ExecutionContext in the call frame (vs ScopeList).
Removes caching of the registers.
Adds caching of the ExecutionContext