### PR TITLE
Log startup timings

### DIFF
--- a/examples/inspector/inspector.html
+++ b/examples/inspector/inspector.html
@@ -83,8 +83,9 @@ limitations under the License.
       </div>
     </div>
     <script>
-      var requiredConsoleFunctions = ["profile", "profileEnd", "markTimeline",
-        "time", "timeEnd"];
+      var initStartTime = Date.now();
+
+      var requiredConsoleFunctions = ["profile", "profileEnd", "markTimeline", "time", "timeEnd"];
       for (var i = 0; i < requiredConsoleFunctions.length; i++) {
         if (!(requiredConsoleFunctions[i] in console))
           console[requiredConsoleFunctions[i]] = function () {};

--- a/examples/inspector/js/inspector.js
+++ b/examples/inspector/js/inspector.js
@@ -247,6 +247,7 @@ function executeFile(path, buffer, movieParams, remoteDebugging) {
         player.stageScale = state.scale;
         player.displayParameters = easel.getDisplayParameters();
         player.loaderUrl = state.loaderURL;
+        player.initStartTime = initStartTime;
 
         var useRecorder = state.recordingLimit > 0;
         easelHost = useRecorder ?

--- a/extension/firefox/chrome/ShumwayCom.jsm
+++ b/extension/firefox/chrome/ShumwayCom.jsm
@@ -356,6 +356,7 @@ function ShumwayChromeActions(startupInfo, window, document) {
   this.isOverlay = startupInfo.isOverlay;
   this.embedTag = startupInfo.embedTag;
   this.isPausedAtStart = startupInfo.isPausedAtStart;
+  this.initStartTime = startupInfo.initStartTime;
   this.window = window;
   this.document = document;
   this.allowScriptAccess = startupInfo.allowScriptAccess;
@@ -415,6 +416,7 @@ ShumwayChromeActions.prototype = {
       objectParams: this.objectParams,
       isOverlay: this.isOverlay,
       isPausedAtStart: this.isPausedAtStart,
+      initStartTime: this.initStartTime,
       isDebuggerEnabled: getBoolPref('shumway.debug.enabled', false)
     };
   },

--- a/extension/firefox/content/ShumwayStreamConverter.jsm
+++ b/extension/firefox/content/ShumwayStreamConverter.jsm
@@ -225,6 +225,7 @@ ShumwayStreamConverterBase.prototype = {
   },
 
   getStartupInfo: function(window, urlHint) {
+    var initStartTime = Date.now();
     var url = urlHint;
     var baseUrl;
     var pageUrl;
@@ -323,6 +324,7 @@ ShumwayStreamConverterBase.prototype = {
     startupInfo.isOverlay = isOverlay;
     startupInfo.embedTag = element;
     startupInfo.isPausedAtStart = /\bpaused=true$/.test(urlHint);
+    startupInfo.initStartTime = initStartTime;
     startupInfo.allowScriptAccess = allowScriptAccess;
     startupInfo.pageIndex = 0;
     return startupInfo;
@@ -387,8 +389,7 @@ ShumwayStreamConverterBase.prototype = {
         aRequest.cancel(Cr.NS_BINDING_ABORTED);
 
         var domWindow = getDOMWindow(channel);
-        let startupInfo = converter.getStartupInfo(domWindow,
-                                                   converter.getUrlHint(originalURI));
+        let startupInfo = converter.getStartupInfo(domWindow, converter.getUrlHint(originalURI));
 
         listener.onStopRequest(aRequest, context, statusCode);
 

--- a/extension/firefox/content/web/viewer.js
+++ b/extension/firefox/content/web/viewer.js
@@ -43,6 +43,8 @@ var playerWindowLoaded = new Promise(function(resolve) {
   playerWindowIframe.src = 'resource://shumway/web/viewer.player.html';
 });
 
+var initStartTime;
+
 function runViewer() {
   var flashParams = ShumwayCom.getPluginParams();
 
@@ -57,6 +59,7 @@ function runViewer() {
   var baseUrl = flashParams.baseUrl;
   var isOverlay = flashParams.isOverlay;
   pauseExecution = flashParams.isPausedAtStart;
+  initStartTime = flashParams.initStartTime;
   var isDebuggerEnabled = flashParams.isDebuggerEnabled;
 
   console.log("url=" + movieUrl + ";params=" + uneval(movieParams));
@@ -202,7 +205,8 @@ function parseSwf(url, baseUrl, movieParams, objectParams) {
       env: playerSettings.env,
       bgcolor: backgroundColor,
       url: url,
-      baseUrl: baseUrl || url
+      baseUrl: baseUrl || url,
+      initStartTime: initStartTime
     }
   };
   playerWindow.postMessage(data,  '*');

--- a/extension/firefox/content/web/viewerPlayer.js
+++ b/extension/firefox/content/web/viewerPlayer.js
@@ -19,11 +19,7 @@ window.print = function(msg) {
 };
 
 function runSwfPlayer(flashParams) {
-  var EXECUTION_MODE = Shumway.AVM2.Runtime.ExecutionMode;
-
-  var compilerSettings = flashParams.compilerSettings;
-  var sysMode = compilerSettings.sysCompiler ? EXECUTION_MODE.COMPILE : EXECUTION_MODE.INTERPRET;
-  var appMode = compilerSettings.appCompiler ? EXECUTION_MODE.COMPILE : EXECUTION_MODE.INTERPRET;
+  console.info('Time from init start to SWF player start: ' + (Date.now() - flashParams.initStartTime));
   var asyncLoading = true;
   var baseUrl = flashParams.baseUrl;
   var objectParams = flashParams.objectParams;
@@ -41,8 +37,10 @@ function runSwfPlayer(flashParams) {
       player.stageAlign = (objectParams && (objectParams.salign || objectParams.align)) || '';
       player.stageScale = (objectParams && objectParams.scale) || 'showall';
       player.displayParameters = flashParams.displayParameters;
+      player.initStartTime = flashParams.initStartTime;
 
       player.pageUrl = baseUrl;
+      console.info('Time from init start to SWF loading start: ' + (Date.now() - flashParams.initStartTime));
       player.load(file, buffer);
     }
 

--- a/src/base/utilities.ts
+++ b/src/base/utilities.ts
@@ -1831,8 +1831,8 @@ module Shumway {
 
     public static logLevel: LogLevel = LogLevel.All;
 
-    private static _consoleOut = console.info.bind(console);
-    private static _consoleOutNoNewline = console.info.bind(console);
+    private static _consoleOut = console.log.bind(console);
+    private static _consoleOutNoNewline = console.log.bind(console);
 
     private _tab: string;
     private _padding: string;

--- a/src/player/player.ts
+++ b/src/player/player.ts
@@ -279,6 +279,11 @@ module Shumway.Player {
     public displayParameters: DisplayParameters;
 
     /**
+     * Timestamp of initialization start of the player itself, including iframe creation.
+     */
+    public initStartTime: number;
+
+    /**
      * Time since the last time we've synchronized the display list.
      */
     private _lastPumpTime = 0;
@@ -557,6 +562,8 @@ module Shumway.Player {
         self._eventLoopTick();
       }
 
+      console.info('Time from init start to main event loop start: ' +
+                   (Date.now() - this.initStartTime));
       tick();
     }
 

--- a/src/shell/domstubs.ts
+++ b/src/shell/domstubs.ts
@@ -24,7 +24,13 @@ declare function print(message: string): void;
 this.console = {
   _print: print,
   log: print,
-  info: print,
+  info: function() {
+    if (!Shumway.Shell.verbose) {
+      return;
+    }
+    print(Shumway.IndentingWriter.YELLOW + [].join.call(arguments, ', ') +
+          Shumway.IndentingWriter.ENDC);
+  },
   warn: function() {
     print(Shumway.IndentingWriter.RED + [].join.call(arguments, ', ') +
           Shumway.IndentingWriter.ENDC);

--- a/src/shell/shell.ts
+++ b/src/shell/shell.ts
@@ -180,7 +180,7 @@ module Shumway.Shell {
     }
   }
 
-  var verbose = false;
+  export var verbose = false;
   var writer = new IndentingWriter();
 
   var parseOption: Option;


### PR DESCRIPTION
Logs the duration of two initialization phases: from startup triggering to player start and from player start to entering of the main loop.

@yurydelendik, I couldn't find a better way of funneling the startup timestamp through. If you see one, please tell me. Otherwise: r?