### PR TITLE
Bug 1137865 - Only show red "Shumway" button in shumway debug mode

### DIFF
--- a/extension/firefox/content/web/viewer.js
+++ b/extension/firefox/content/web/viewer.js
@@ -74,17 +74,19 @@ function runViewer() {
   });
 
   if (isOverlay) {
-    document.getElementById('overlay').className = 'enabled';
-    var fallbackDiv = document.getElementById('fallback');
-    fallbackDiv.addEventListener('click', function(e) {
-      fallback();
-      e.preventDefault();
-    });
-    var reportDiv = document.getElementById('report');
-    reportDiv.addEventListener('click', function(e) {
-      reportIssue();
-      e.preventDefault();
-    });
+    if (isDebuggerEnabled) {
+      document.getElementById('overlay').className = 'enabled';
+      var fallbackDiv = document.getElementById('fallback');
+      fallbackDiv.addEventListener('click', function (e) {
+        fallback();
+        e.preventDefault();
+      });
+      var reportDiv = document.getElementById('report');
+      reportDiv.addEventListener('click', function (e) {
+        reportIssue();
+        e.preventDefault();
+      });
+    }
     var fallbackMenu = document.getElementById('fallbackMenu');
     fallbackMenu.removeAttribute('hidden');
     fallbackMenu.addEventListener('click', fallback);


### PR DESCRIPTION
This leaves debugging-related context menu entries enabled. We can disable them later when we ride the trains.