### PR TITLE
Implement support for Loader#close

### DIFF
--- a/examples/inspector/js/remoteDebugging.js
+++ b/examples/inspector/js/remoteDebugging.js
@@ -70,6 +70,7 @@ function remoteDebuggerInitServices() {
     setFullscreen: function (enabled) { remoteDebuggerSendMessage('setFullscreen', enabled, true); },
     externalCom: function (args) { return remoteDebuggerSendMessage('externalCom', args, false); },
     loadFile: function (args) { remoteDebuggerSendMessage('loadFile', args, true); },
+    abortLoad: function (sessionId) { remoteDebuggerSendMessage('abortLoad', sessionId, true); },
     navigateTo: function (args) { remoteDebuggerSendMessage('navigateTo', args, true); },
 
     setLoadFileCallback: function (callback) { shumwayComLoadFileCallback = callback; },

--- a/extension/firefox/chrome/ShumwayCom.jsm
+++ b/extension/firefox/chrome/ShumwayCom.jsm
@@ -203,6 +203,11 @@ var ShumwayCom = {
         callbacks.sendMessage('loadFile', request, false);
       },
 
+      abortLoad: function abortLoad(sessionId) {
+        sessionId = sessionId|0;
+        callbacks.sendMessage('abortLoad', sessionId, false);
+      },
+
       reportTelemetry: function reportTelemetry(args) {
         var request = sanitizeTelemetryArgs(args);
         callbacks.sendMessage('reportTelemetry', request, false);
@@ -421,6 +426,10 @@ ShumwayChromeActions.prototype = {
 
   loadFile: function loadFile(data) {
     this.fileLoader.load(data);
+  },
+
+  abortLoad: function abortLoad(sessionId) {
+    this.fileLoader.abort(sessionId);
   },
 
   navigateTo: function (data) {

--- a/src/base/binaryFileReader.ts
+++ b/src/base/binaryFileReader.ts
@@ -28,6 +28,7 @@ module Shumway {
     method: string;
     mimeType: string;
     data: any;
+    xhr: XMLHttpRequest;
 
     constructor(url: string, method?: string, mimeType?: string, data?) {
       this.url = url;
@@ -39,7 +40,7 @@ module Shumway {
     readAll(progress: (response: any, loaded: number, total: number) => void,
             complete: (response: any, error?: any) => void) {
       var url = this.url;
-      var xhr = new XMLHttpRequest({mozSystem: true});
+      var xhr = this.xhr = new XMLHttpRequest({mozSystem: true});
       var async = true;
       xhr.open(this.method || "GET", this.url, async);
       xhr.responseType = "arraybuffer";
@@ -112,7 +113,7 @@ module Shumway {
               onopen?: () => void,
               oncomplete?: () => void,
               onhttpstatus?: (location: string, status: string, responseHeaders: any) => void) {
-      var xhr = new XMLHttpRequest({mozSystem: true});
+      var xhr = this.xhr = new XMLHttpRequest({mozSystem: true});
       var url = this.url;
       var loaded = 0;
       var total = 0;
@@ -158,6 +159,13 @@ module Shumway {
       xhr.send(this.data || null);
       if (onopen) {
         onopen();
+      }
+    }
+
+    abort() {
+      if (this.xhr) {
+        this.xhr.abort();
+        this.xhr = null;
       }
     }
   }

--- a/src/base/external.ts
+++ b/src/base/external.ts
@@ -31,6 +31,7 @@ declare var ShumwayCom: {
   setFullscreen: (enabled: boolean) => void;
   externalCom: (args: any) => any;
   loadFile: (args: any) => void;
+  abortLoad: (sessionId: number) => void;
   loadSystemResource: (id: number) => void;
   navigateTo: (args: any) => void;
   setupComBridge: (playerWindow: any) => void;

--- a/src/player/external.ts
+++ b/src/player/external.ts
@@ -110,7 +110,7 @@ module Shumway.Player {
         },
         close: function () {
           if (service._sessions[sessionId]) {
-            // TODO send abort
+            ShumwayCom.abortLoad(sessionId);
           }
         }
       };
@@ -148,12 +148,15 @@ module Shumway.Player {
 
     createSession() {
       var service = this;
+      var reader: Shumway.BinaryFileReader;
       return {
         open: function (request) {
           var self: any = this;
           var path = service.resolveUrl(request.url);
           console.log('FileLoadingService: loading ' + path + ", data: " + request.data);
-          new Shumway.BinaryFileReader(path, request.method, request.mimeType, request.data).readChunked(
+          reader = new Shumway.BinaryFileReader(path, request.method, request.mimeType,
+                                                request.data);
+          reader.readChunked(
             service._fileReadChunkSize,
             function (data, progress) {
               self.onprogress(data, {bytesLoaded: progress.loaded, bytesTotal: progress.total});
@@ -164,7 +167,8 @@ module Shumway.Player {
             self.onhttpstatus);
         },
         close: function () {
-          // TODO abort BinaryFileReader
+          reader.abort();
+          reader = null;
         }
       };
     }

--- a/src/shell/playerservices.ts
+++ b/src/shell/playerservices.ts
@@ -44,10 +44,10 @@ module Shumway.Shell
       this.readAll(null, function (data, err) {
         if (data) {
           ondata(data, { loaded: data.byteLength, total: data.byteLength});
+          oncomplete();
         } else {
           onerror(err);
         }
-        oncomplete();
       });
     }
   }

--- a/src/swf/FileLoader.ts
+++ b/src/swf/FileLoader.ts
@@ -134,7 +134,9 @@ module Shumway {
       session.open(request);
     }
     abortLoad() {
-      // TODO: implement
+      this._loadingServiceSession.close();
+      this._file = null;
+      SWF.leaveTimeline();
     }
     loadBytes(bytes: Uint8Array) {
       SWF.enterTimeline('Load bytes');
@@ -199,7 +201,9 @@ module Shumway {
         this.processSWFFileUpdate(file, eagerlyParsedSymbolsCount, previousFramesLoaded);
       }
       if (!file || file.bytesLoaded !== file.bytesTotal) {
-        Debug.warning("Not Implemented: processing loadClose when loading was aborted");
+        Debug.warning("Shouldn't have reached this: aborting a load should prevent this from " +
+                      "being called.");
+        Debug.warning(new Error().stack);
       } else {
         SWF.leaveTimeline();
       }

--- a/test/test_avm2_ats.baseline
+++ b/test/test_avm2_ats.baseline
@@ -1255,7 +1255,6 @@ Frame: 1 HASHCODE: test/ats/swfs/03398183f32bcf40113d61d80ff73c7ebae01eaf79e94c2
 [video-main][v1.0][LoaderBase] loadSwfFrom() http://disney.ff0000-cdn.net/2014/FY15__Disney_Side/core_family_160x600_ext.swf 
 [91msomewhatImplemented: public flash.system.Security::get sandboxType[0m
 [91mLoading error encountered:, Can't read http://disney.ff0000-cdn.net/2014/FY15__Disney_Side/core_family_160x600_ext.swf[0m
-[91mNot Implemented: processing loadClose when loading was aborted[0m
 Frame: 2 HASHCODE: test/ats/swfs/03398183f32bcf40113d61d80ff73c7ebae01eaf79e94c2e4ebe3c1c17c8fdb4432bcbc656e6e6b814b4539c81c644f0c661c0ab6bcbf274b134a96621a6b4ad.swf: 0x5a87bb32
 Frame: 3 HASHCODE: test/ats/swfs/03398183f32bcf40113d61d80ff73c7ebae01eaf79e94c2e4ebe3c1c17c8fdb4432bcbc656e6e6b814b4539c81c644f0c661c0ab6bcbf274b134a96621a6b4ad.swf: 0x3018910e
 Frame: 4 HASHCODE: test/ats/swfs/03398183f32bcf40113d61d80ff73c7ebae01eaf79e94c2e4ebe3c1c17c8fdb4432bcbc656e6e6b814b4539c81c644f0c661c0ab6bcbf274b134a96621a6b4ad.swf: 0x964cd8c8

--- a/test/test_mock.baseline
+++ b/test/test_mock.baseline
@@ -16,7 +16,6 @@ Frame: 1 HASHCODE: examples/jwplayer/jwplayer.flash.swf: 0x00000000
 [91msomewhatImplemented: public flash.system.Capabilities::get isDebugger[0m
 Frame: 2 HASHCODE: examples/jwplayer/jwplayer.flash.swf: 0x6ba9ad56
 [91mLoading error encountered:, Can't read examples/jwplayer/../examples/image-loading/firefox.png[0m
-[91mNot Implemented: processing loadClose when loading was aborted[0m
 [91msomewhatImplemented: public flash.text.TextField::getCharBoundaries[0m
 Frame: 3 HASHCODE: examples/jwplayer/jwplayer.flash.swf: 0x2d0615d0
 [91msomewhatImplemented: public flash.net.SharedObject::flush[0m


### PR DESCRIPTION
Gets rid of the pesky `Not Implemented: processing loadClose when loading was aborted` warning.

r? @yurydelendik