### PR TITLE
Add method for stringifying objects without producing uncaught exceptions

### DIFF
--- a/src/base/utilities.ts
+++ b/src/base/utilities.ts
@@ -262,6 +262,27 @@ module Shumway {
     return value == undefined;
   }
 
+  export function argumentsToString(args: IArguments) {
+    var resultList = [];
+    for (var i = 0; i < args.length; i++) {
+      var arg = args[i];
+      try {
+        var argStr;
+        if (typeof arg !== 'object' || !arg) {
+          argStr = arg + '';
+        } else if ('toString' in arg) {
+          argStr + arg.toString();
+        } else {
+          argStr = Object.prototype.toString.call(arg);
+        }
+        resultList.push(argStr);
+      } catch (e) {
+        resultList.push('<unprintable value>');
+      }
+    }
+    return resultList.join(', ');
+  }
+
   export module Debug {
     export function error(message: string) {
       console.error(message);
@@ -299,7 +320,7 @@ module Shumway {
       if (release) {
         return;
       }
-      var key = Array.prototype.join.call(arguments, ',');
+      var key = argumentsToString(arguments);
       if (_warnedCounts[key]) {
         _warnedCounts[key]++;
         if (Shumway.omitRepeatedWarnings.value) {

--- a/src/shell/domstubs.ts
+++ b/src/shell/domstubs.ts
@@ -20,7 +20,6 @@ this.self = this;
 this.window = this;
 
 declare function print(message: string): void;
-
 this.console = {
   _print: print,
   log: print,
@@ -28,15 +27,15 @@ this.console = {
     if (!Shumway.Shell.verbose) {
       return;
     }
-    print(Shumway.IndentingWriter.YELLOW + [].join.call(arguments, ', ') +
+    print(Shumway.IndentingWriter.YELLOW + Shumway.argumentsToString(arguments) +
           Shumway.IndentingWriter.ENDC);
   },
   warn: function() {
-    print(Shumway.IndentingWriter.RED + [].join.call(arguments, ', ') +
+    print(Shumway.IndentingWriter.RED + Shumway.argumentsToString(arguments) +
           Shumway.IndentingWriter.ENDC);
   },
   error: function() {
-    print(Shumway.IndentingWriter.BOLD_RED + [].join.call(arguments, ', ') +
+    print(Shumway.IndentingWriter.BOLD_RED + Shumway.argumentsToString(arguments) +
           Shumway.IndentingWriter.ENDC + '\nstack:\n' + (new Error().stack));
   },
   time: function () {},
@@ -45,7 +44,7 @@ this.console = {
 
 declare var putstr;
 this.dump = function (message) {
-  putstr(message);
+  putstr(Shumway.argumentsToString(arguments));
 };
 
 this.addEventListener = function (type) {


### PR DESCRIPTION
And use it in logging functions.

This prevents situations where logging a warning breaks the application. Note that this can still happen if calling `toString` on an object in the log message causes side-effects that break the application, but it's much less likely.