### PR TITLE
WIP: Implement BitmapData#getColorBoundsRect

### DIFF
--- a/src/base/utilities.ts
+++ b/src/base/utilities.ts
@@ -3217,6 +3217,30 @@ module Shumway {
       return Math.max(0, Math.min(255, value));
     }
 
+    export function uARGBToImagePixel(value: number, imageType: ImageType) {
+      switch (imageType) {
+        case ImageType.PremultipliedAlphaARGB:
+          return premultiplyARGB(value);
+        case ImageType.StraightAlphaRGBA:
+          return swap32(ARGBToRGBA(value));
+        default:
+          Shumway.Debug.notImplemented(ImageType[this._type]);
+          return 0;
+      }
+    }
+
+    export function imagePixelToUARGB(value: number, imageType: ImageType) {
+      switch (imageType) {
+        case ImageType.PremultipliedAlphaARGB:
+          return unpremultiplyARGB(swap32(value)) >>> 0;
+        case ImageType.StraightAlphaRGBA:
+          return RGBAToARGB(swap32(value));
+        default:
+          Shumway.Debug.notImplemented(ImageType[this._type]);
+          return 0;
+      }
+    }
+
     /**
      * Unpremultiplies the given |pARGB| color value.
      */


### PR DESCRIPTION
And required fixes to BitmapData. Very WIP, much broken.

There is so much inconsistency in BitmapData, particularly around handling of color formats. I think we need to clean all that up, and sooner rather than later, to be able to say, with a straight face, that we support any methods on BitmapData at all.

In particular, various methods just assume the data to be in pARGB format, while others think it's uRGBA. With some uncertainty about byte order sprinkled in. The comment on `_ensureBitmapData` tells a story about converting things to uRGBA, but the implementation converts to pARGB.

Fun.