### PR TITLE
Guard during frame parsing when soundstreanhead is not supported.

### DIFF
--- a/src/flash/display/MovieClip.ts
+++ b/src/flash/display/MovieClip.ts
@@ -778,6 +778,9 @@ module Shumway.AVMX.AS.flash.display {
     }
 
     _addSoundStreamBlock(frameNum: number, streamBlock: any) {
+      if (this._sounds === null) {
+        this._sounds = new MovieClipSoundsManager(this);
+      }
       this._sounds.addSoundStreamBlock(frameNum, streamBlock);
     }
 

--- a/src/flash/display/MovieClipSoundStream.ts
+++ b/src/flash/display/MovieClipSoundStream.ts
@@ -298,7 +298,7 @@ module Shumway.AVMX.AS.flash.display {
 
     public constructor(streamInfo: SWF.Parser.SoundStream, movieClip: MovieClip) {
       this.movieClip = movieClip;
-      this.decode = streamInfo.decode;
+      this.decode = streamInfo.decode.bind(streamInfo);
       this.data = {
         sampleRate: streamInfo.sampleRate,
         channels: streamInfo.channels

--- a/src/swf/parser/sound.ts
+++ b/src/swf/parser/sound.ts
@@ -252,7 +252,7 @@ module Shumway.SWF.Parser {
           stream.decode = SwfSoundStream_decode_MP3;
           break;
         default:
-          Debug.warning('Unsupported audio format: ' + tag.soundFormat);
+          Debug.warning('Unsupported audio stream format: ' + tag.streamCompression);
           return null;
       }
 


### PR DESCRIPTION
Fixes this._sounds is null errors during parsing.

Needs ADPCM support for in-SWF stream sounds.