### PR TITLE
Bug 1165143 - Use progressInfo to determine SWF loading completed.

### DIFF
--- a/src/swf/FileLoader.ts
+++ b/src/swf/FileLoader.ts
@@ -152,7 +152,8 @@ module Shumway {
     }
     processNewData(data: Uint8Array, progressInfo: {bytesLoaded: number; bytesTotal: number}) {
       this._bytesLoaded += data.length;
-      if (this._bytesLoaded < MIN_LOADED_BYTES && this._bytesLoaded < progressInfo.bytesTotal) {
+      var isLoadingInProgress = progressInfo.bytesLoaded < progressInfo.bytesTotal;
+      if (this._bytesLoaded < MIN_LOADED_BYTES && isLoadingInProgress) {
         if (!this._queuedInitialData) {
           this._queuedInitialData = new Uint8Array(Math.min(MIN_LOADED_BYTES,
                                                             progressInfo.bytesTotal));


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1165143

That connected with how HTTP server encodes data -- in this case it is gzip and it got bigger than actual SWF. Fixes that. But we have never use progressInfo.bytesTotal as final length information (filed https://bugzilla.mozilla.org/show_bug.cgi?id=1165322).