### PR TITLE
Bug 1163206 - Disable HTTP referer for non-overlay and non-HTTPS.

### DIFF
--- a/extension/firefox/chrome/ShumwayCom.jsm
+++ b/extension/firefox/chrome/ShumwayCom.jsm
@@ -389,9 +389,8 @@ function ShumwayChromeActions(startupInfo, window, document) {
     errors: []
   };
 
-  this.fileLoader = new FileLoader(startupInfo.url, startupInfo.baseUrl, function (args) {
-    this.onLoadFileCallback(args);
-  }.bind(this));
+  this.fileLoader = new FileLoader(startupInfo.url, startupInfo.baseUrl, startupInfo.refererUrl,
+    function (args) { this.onLoadFileCallback(args); }.bind(this));
   this.onLoadFileCallback = null;
 
   this.externalInterface = null;


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=1163206

