### PR TITLE
Refactors AVM1 object initialization and DoInitAction.

### DIFF
--- a/src/avm1/context.ts
+++ b/src/avm1/context.ts
@@ -35,7 +35,6 @@ module Shumway.AVM1 {
   export interface AVM1ExportedSymbol {
     symbolId: number;
     symbolProps;
-    theClass;
   }
 
   export interface IAVM1RuntimeUtils {
@@ -162,6 +161,9 @@ module Shumway.AVM1 {
       }
       this.assetsClasses[symbolId] = theClass;
     }
+    public getSymbolClass(symbolId: number) : AVM1Object {
+      return this.assetsClasses[symbolId] || null;
+    }
     public getAsset(className: string) : AVM1ExportedSymbol {
       className = alCoerceString(this, className);
       if (className === null) {
@@ -182,8 +184,7 @@ module Shumway.AVM1 {
       }
       return {
         symbolId: symbolId,
-        symbolProps: symbol,
-        theClass: this.assetsClasses[symbolId]
+        symbolProps: symbol
       };
     }
 

--- a/src/avm1/flash.d.ts
+++ b/src/avm1/flash.d.ts
@@ -279,7 +279,6 @@ declare module Shumway.AVMX.AS.flash {
     }
     class SpriteSymbol extends DisplaySymbol {
       avm1Name: string;
-      avm1SymbolClass;
     }
 
     enum LookupChildOptions {

--- a/src/avm1/lib/AVM1MovieClip.ts
+++ b/src/avm1/lib/AVM1MovieClip.ts
@@ -117,7 +117,6 @@ module Shumway.AVM1.Lib {
 
       var props: flash.display.SpriteSymbol = Object.create(symbol.symbolProps);
       props.avm1Name = name;
-      props.avm1SymbolClass = symbol.theClass;
 
       var mc:flash.display.MovieClip;
       mc = Shumway.AVMX.AS.constructClassFromSymbol(props, this.context.sec.flash.display.MovieClip.axClass);
@@ -637,57 +636,6 @@ module Shumway.AVM1.Lib {
         processed[normalizedName] = true;
       }
       return Object.getOwnPropertyNames(processed);
-    }
-
-    addFrameActionBlocks(frameIndex: number, frameData: any) {
-      var initActionBlocks: any[] = frameData.initActionBlocks;
-      var actionBlocks: any[] = frameData.actionBlocks;
-
-      if (initActionBlocks) {
-        this._addInitActionBlocks(frameIndex, initActionBlocks);
-      }
-
-      if (actionBlocks) {
-        for (var i = 0; i < actionBlocks.length; i++) {
-          this.addFrameScript(frameIndex, actionBlocks[i]);
-        }
-      }
-    }
-    
-    addFrameScript(frameIndex: number, actionsBlock: any): void {
-      var actionsData = this.context.actionsDataFactory.createActionsData(
-        actionsBlock.actionsData, 's' + this.as3Object._symbol.id + 'f' + frameIndex);
-      var script = this.context.executeActions.bind(this.context, actionsData, this);
-      script.precedence = actionsBlock.precedence;
-      this.as3Object.addFrameScript(frameIndex, script);
-    }
-
-    /**
-     * AVM1 InitActionBlocks are executed once, before the children are initialized for a frame.
-     * That matches AS3's enterFrame event, so we can add an event listener that just bails
-     * as long as the target frame isn't reached, and executes the InitActionBlock once it is.
-     *
-     * After that, the listener removes itself.
-     */
-    private _addInitActionBlocks(frameIndex: number,
-                                 actionsBlocks: {actionsData: Uint8Array} []): void
-    {
-      var avm2MovieClip = this.as3Object;
-      var self = this;
-      function listener (e) {
-        if (avm2MovieClip.currentFrame !== frameIndex + 1) {
-          return;
-        }
-        avm2MovieClip.removeEventListener('enterFrame', listener);
-
-        var avm1Context = self.context;
-        for (var i = 0; i < actionsBlocks.length; i++) {
-          var actionsData = avm1Context.actionsDataFactory.createActionsData(
-            actionsBlocks[i].actionsData, 's' + avm2MovieClip._symbol.id + 'f' + frameIndex + 'i' + i);
-          avm1Context.executeActions(actionsData, self);
-        }
-      }
-      avm2MovieClip.addEventListener('enterFrame', listener);
     }
 
     private _init(initObject) {

--- a/src/avm1/lib/AVM1Utils.ts
+++ b/src/avm1/lib/AVM1Utils.ts
@@ -602,8 +602,10 @@ module Shumway.AVM1.Lib {
     }
     var sec = context.sec;
     if (sec.flash.display.MovieClip.axClass.axIsType(as3Object)) {
-      if (<flash.display.MovieClip>as3Object._avm1SymbolClass) {
-        return createAVM1NativeObject(<flash.display.MovieClip>as3Object._avm1SymbolClass, as3Object, context);
+      var theClass = as3Object._symbol &&
+                     context.getSymbolClass(as3Object._symbol.data.id);
+      if (theClass) {
+        return createAVM1NativeObject(theClass, as3Object, context);
       }
       return createAVM1NativeObject(context.globals.MovieClip, as3Object, context);
     }

--- a/src/flash/avm1.d.ts
+++ b/src/flash/avm1.d.ts
@@ -19,9 +19,13 @@ import ASClass = Shumway.AVMX.AS.ASClass;
 declare module Shumway.AVM1 {
   import flash = Shumway.AVMX.AS.flash;
 
+  export class ActionsDataFactory {
+    public createActionsData(bytes: Uint8Array, id: string, parent?: AVM1ActionsData): AVM1ActionsData;
+  }
   export class AVM1ActionsData {
   }
   export class AVM1Context {
+    actionsDataFactory: ActionsDataFactory;
     static create(loaderInfo: flash.display.LoaderInfo): AVM1Context;
     addAsset(className: string, symbolId: number, symbolProps): void;
     executeActions(actionsData: AVM1ActionsData, scopeObj): void;
@@ -35,8 +39,6 @@ declare module Shumway.AVM1 {
     function initializeAVM1Object(as3Object: flash.display.DisplayObject, context: AVM1Context,
                                   placeObjectTag: Shumway.SWF.PlaceObjectTag): void;
     class AVM1MovieClip extends AVM1Object {
-      addFrameActionBlocks(frameIndex: number, frameData: any): void;
-      addFrameScript(frameIndex: number, actionsBlock: Uint8Array): void;
       setParameters(parameters: any): void;
     }
   }

--- a/src/flash/display/DisplayObject.ts
+++ b/src/flash/display/DisplayObject.ts
@@ -180,6 +180,12 @@ module Shumway.AVMX.AS.flash.display {
     CacheAsBitmap                             = 0x010000,
 
     /**
+     * Indicates whether an AVM1 timeline needs to initialize an object after place object
+     * occurred.
+     */
+    HasPlaceObjectInitPending                 = 0x020000,
+
+    /**
      * Indicates whether this display object's matrix has changed since the last time it was
      * synchronized.
      */
@@ -788,6 +794,7 @@ module Shumway.AVMX.AS.flash.display {
     _mouseDown: boolean;
 
     _symbol: Shumway.Timeline.DisplaySymbol;
+    _placeObjectTag: Shumway.SWF.PlaceObjectTag;
     _graphics: flash.display.Graphics;
 
     /**

--- a/src/flash/display/DisplayObjectContainer.ts
+++ b/src/flash/display/DisplayObjectContainer.ts
@@ -102,7 +102,12 @@ module Shumway.AVMX.AS.flash.display {
         child._setFlags(DisplayObjectFlags.Constructed);
 
         var eventClass = this.sec.flash.events.Event.axClass;
-        if (child._symbol && child._symbol.isAVM1Object) {
+        if (child._hasFlags(DisplayObjectFlags.HasPlaceObjectInitPending)) {
+          child._removeFlags(DisplayObjectFlags.HasPlaceObjectInitPending);
+
+          var avm1Context = child._symbol.avm1Context;
+          Shumway.AVM1.Lib.initializeAVM1Object(child, avm1Context, child._placeObjectTag);
+
           try {
             child.dispatchEvent(eventClass.getInstance(events.Event.AVM1_INIT));
           } catch (e) {

--- a/src/flash/display/Sprite.ts
+++ b/src/flash/display/Sprite.ts
@@ -207,7 +207,8 @@ module Shumway.AVMX.AS.flash.display {
               child = this.createAnimatedDisplayObject(symbol, placeObjectTag, false);
               this.addTimelineObjectAtDepth(child, depth);
               if (symbol.isAVM1Object) {
-                Shumway.AVM1.Lib.initializeAVM1Object(child, symbol.avm1Context, placeObjectTag);
+                child._placeObjectTag = placeObjectTag;
+                child._setFlags(DisplayObjectFlags.HasPlaceObjectInitPending);
               }
             }
             break;
@@ -388,10 +389,8 @@ module Shumway.AVMX.AS.flash.display {
     numFrames: number = 1;
     frames: any[] = [];
     labels: flash.display.FrameLabel[] = [];
-    frameScripts: any[] = [];
     isRoot: boolean;
     avm1Name: string;
-    avm1SymbolClass;
     loaderInfo: flash.display.LoaderInfo;
 
     constructor(data: Timeline.SymbolData, loaderInfo: flash.display.LoaderInfo) {
@@ -406,18 +405,10 @@ module Shumway.AVMX.AS.flash.display {
         symbol.isAVM1Object = true;
         symbol.avm1Context = loaderInfo._avm1Context;
       }
-      symbol.frameScripts = [];
       var frames = data.frames;
       var frameLabelCtor = loaderInfo.app.sec.flash.display.FrameLabel;
       for (var i = 0; i < frames.length; i++) {
         var frame = loaderInfo.getFrame(data, i);
-        var actionBlocks = frame.actionBlocks;
-        if (actionBlocks) {
-          for (var j = 0; j < actionBlocks.length; j++) {
-            symbol.frameScripts.push(i);
-            symbol.frameScripts.push(actionBlocks[j]);
-          }
-        }
         if (frame.labelName) {
           symbol.labels.push(new frameLabelCtor(frame.labelName, i + 1));
         }

--- a/test/test_manifest_bad.json
+++ b/test/test_manifest_bad.json
@@ -6,13 +6,6 @@
     ],
     "type": "stas"
   },
-  {  "id": "avm1core",
-    "stas": "swfs/trace.stas",
-    "filenames": [
-      "swfs/avm1/doactionorder/symbolclass.swf"
-    ],
-    "type": "stas"
-  },
   {  "id": "AVM1Movie",
     "stas": "swfs/trace.stas",
     "filenames": [

--- a/test/test_manifest_trace.json
+++ b/test/test_manifest_trace.json
@@ -24,6 +24,7 @@
         "swfs/avm1/array/arraygeneric.swf",
         "swfs/avm1/propertycase/propertycase.swf",
         "swfs/avm1/scope/avm1-scope-1.swf",
+        "swfs/avm1/doactionorder/symbolclass.swf",
         "swfs/avm1/doactionorder/doactionorder.swf"
       ],
       "type": "stas"


### PR DESCRIPTION
(redo of #2261)

New advance step for DoInitAction is created -- it is initializing scripts and (if needed) executing init blocks.

The AVM1 specific methods were moved from AVM1MovieClip has to be moved (currently to the MovieClip) since during scripts initialization and children construction, AVM1 objects shall not exist.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2264)
<!-- Reviewable:end -->
