### PR TITLE
Font symbol fixes

### DIFF
--- a/src/flash/text/Font.ts
+++ b/src/flash/text/Font.ts
@@ -819,23 +819,20 @@ module Shumway.AVMX.AS.flash.text {
       // Font symbols without any glyphs describe device fonts.
       this._fontType = metrics ? FontType.EMBEDDED : FontType.DEVICE;
 
-      var fontProp = Object.getOwnPropertyDescriptor(fontClass._fontsBySymbolId, symbol.syncId + '');
-      // Define mapping or replace lazy getter with value.
-      if (!fontProp || !fontProp.value) {
-        // Keeping resolverProp.configurable === true, some old movies might
-        // have fonts with non-unique names.
-        var resolverProp = {
-          value: this,
-          configurable: true
-        };
-        Object.defineProperty(fontClass._fontsBySymbolId, symbol.id + '', resolverProp);
-        Object.defineProperty(fontClass._fontsByName, symbol.name.toLowerCase() + this._fontStyle, resolverProp);
-        if (this._fontType === FontType.EMBEDDED) {
-          Object.defineProperty(fontClass._fontsByName, 'swffont' + symbol.syncId + this._fontStyle, resolverProp);
-        }
+      // Keeping fontProp.configurable === true, some old movies have fonts with non-unique
+      // names.
+      var fontProp = {
+        value: this,
+        configurable: true
+      };
+      Object.defineProperty(fontClass._fontsBySymbolId, symbol.id + '', fontProp);
+      Object.defineProperty(fontClass._fontsByName, symbol.name.toLowerCase() + this._fontStyle,
+                            fontProp);
+      if (this._fontType === FontType.EMBEDDED) {
+        Object.defineProperty(fontClass._fontsByName, 'swffont' + symbol.syncId + this._fontStyle,
+                              fontProp);
       }
     }
-
     constructor() {
       super();
       if (!this._symbol) {
@@ -931,12 +928,13 @@ module Shumway.AVMX.AS.flash.text {
       Object.defineProperty(this._fontsByName, key, resolverProp);
       Object.defineProperty(this._fontsByName, 'swffont' + syncId + fontMapping.style,
                             resolverProp);
-      Object.defineProperty(this._fontsBySymbolId, syncId + '', resolverProp);
+      Object.defineProperty(this._fontsBySymbolId, fontMapping.id + '', resolverProp);
     }
 
     static resolveFontSymbol(loaderInfo: flash.display.LoaderInfo, id: number, syncId: number,
                              key: string) {
       // Force font resolution and installation in _fontsByName and _fontsBySymbolId.
+      release || assert('get' in Object.getOwnPropertyDescriptor(this._fontsBySymbolId, id + ''));
       var symbol = <FontSymbol>loaderInfo.getSymbolById(id);
       symbol.syncId = syncId;
       release || assert('value' in Object.getOwnPropertyDescriptor(this._fontsBySymbolId, id + ''));

--- a/src/gfx/renderables/renderables.ts
+++ b/src/gfx/renderables/renderables.ts
@@ -1661,13 +1661,19 @@ module Shumway.GFX {
       var lines = this.lines;
       var coords = this._coords;
       coords.position = 0;
+      var font = '';
+      var fillStyle = '';
       for (var i = 0; i < lines.length; i++) {
         var line = lines[i];
         var runs = line.runs;
         for (var j = 0; j < runs.length; j++) {
           var run = runs[j];
-          context.font = run.font;
-          context.fillStyle = run.fillStyle;
+          if (run.font !== font) {
+            context.font = font = run.font;
+          }
+          if (run.fillStyle !== fillStyle) {
+            context.fillStyle = fillStyle = run.fillStyle;
+          }
           var text = run.text;
           for (var k = 0; k < text.length; k++) {
             var x = coords.readInt() / 20;
@@ -1688,6 +1694,10 @@ module Shumway.GFX {
       var lines = this.lines;
       var scrollV = this._scrollV;
       var scrollY = 0;
+      var font = '';
+      var fillStyle = '';
+      context.textAlign = "left";
+      context.textBaseline = "alphabetic";
       for (var i = 0; i < lines.length; i++) {
         var line = lines[i];
         var x = line.x;
@@ -1706,13 +1716,15 @@ module Shumway.GFX {
         var runs = line.runs;
         for (var j = 0; j < runs.length; j++) {
           var run = runs[j];
-          context.font = run.font;
-          context.fillStyle = run.fillStyle;
+          if (run.font !== font) {
+            context.font = font = run.font;
+          }
+          if (run.fillStyle !== fillStyle) {
+            context.fillStyle = fillStyle = run.fillStyle;
+          }
           if (run.underline) {
             context.fillRect(x, (y + (line.descent / 2)) | 0, run.width, 1);
           }
-          context.textAlign = "left";
-          context.textBaseline = "alphabetic";
           context.fillText(run.text, x, y);
           x += run.width;
         }

--- a/src/swf/SWFFile.ts
+++ b/src/swf/SWFFile.ts
@@ -728,8 +728,9 @@ module Shumway.SWF {
       var symbol = new EagerlyParsedDictionaryEntry(definition.id, unparsed, 'font', definition,
                                                     this.env);
       if (!release && traceLevel.value > 0) {
-        console.info("Decoding embedded font " + definition.id + " with name '" +
-                     definition.name + "'", definition);
+        var style = flagsToFontStyle(definition.bold, definition.italic);
+        console.info("Decoding embedded font " + definition.id + " with name '" + definition.name +
+                     "' and style " + style, definition);
       }
       this.eagerlyParsedSymbolsMap[symbol.id] = symbol;
       this.eagerlyParsedSymbolsList.push(symbol);
@@ -754,7 +755,7 @@ module Shumway.SWF {
         style = 'regular';
       } else {
         var flags = this.data[stream.pos + 2];
-        style = flagsToFontStyle(!!(flags & 0x2), !!(flags & 0x1));
+        style = flagsToFontStyle(!!(flags & 0x1), !!(flags & 0x2));
         var nameLength = this.data[stream.pos + 4];
         // Skip language code.
         stream.pos += 5;
@@ -762,7 +763,8 @@ module Shumway.SWF {
       }
       this.fonts.push({name: name, id: id, style: style});
       if (!release && traceLevel.value > 0) {
-        console.info("Registering embedded font " + id + " with name '" + name + "'");
+        console.info("Registering embedded font " + id + " with name '" + name + "' and style " +
+                     style);
       }
       stream.pos = unparsed.byteOffset + unparsed.byteLength;
     }


### PR DESCRIPTION
This fixes two issues with font symbols: the Firefox-only mapping for lazily parsed fonts interpreted font style flags incorrectly; and `Font#applySymbol` registered the symbol-id-to-symbol mapping with the `syncID` instead of the symbol id.

Also contains a commit with a very slight optimization to text rendering.

r? @tobytailor

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2269)
<!-- Reviewable:end -->
