### PR TITLE
Bug 1171456 - Work around incorrect bytesloaded/total values reported in XHR progress events

### DIFF
--- a/extension/firefox/chrome/FileLoader.jsm
+++ b/extension/firefox/chrome/FileLoader.jsm
@@ -93,11 +93,17 @@ FileLoader.prototype = {
       var lastPosition = 0;
       xhr.onprogress = function (e) {
         var position = e.loaded;
+        var total = e.total;
         var data = new Uint8Array(xhr.response);
+        // The event's `loaded` and `total` properties are sometimes lower than the actual
+        // number of loaded bytes. In that case, increase them to that value.
+        position = Math.max(position, data.byteLength);
+        total = Math.max(total, data.byteLength);
+
         notifyLoadFileListener({callback:"loadFile", sessionId: sessionId,
-          topic: "progress", array: data, loaded: position, total: e.total});
+          topic: "progress", array: data, loaded: position, total: total});
         lastPosition = position;
-        if (limit && e.total >= limit) {
+        if (limit && total >= limit) {
           xhr.abort();
         }
       };

--- a/src/base/binaryFileReader.ts
+++ b/src/base/binaryFileReader.ts
@@ -124,10 +124,17 @@ module Shumway {
         xhr.responseType = 'arraybuffer';
       }
       xhr.onprogress = function (e) {
-        if (isNotProgressive) return;
+        if (isNotProgressive) {
+          return;
+        }
         loaded = e.loaded;
         total = e.total;
-        ondata(new Uint8Array(xhr.response), { loaded: loaded, total: total });
+        var bytes = new Uint8Array(xhr.response);
+        // The event's `loaded` and `total` properties are sometimes lower than the actual
+        // number of loaded bytes. In that case, increase them to that value.
+        loaded = Math.max(loaded, bytes.byteLength);
+        total = Math.max(total, bytes.byteLength);
+        ondata(bytes, { loaded: loaded, total: total });
       };
       xhr.onreadystatechange = function (event) {
         if (xhr.readyState === 2 && onhttpstatus) {


### PR DESCRIPTION
... by always using the higher value between the event's properties and the loaded buffer's `byteLength`.

r? @yurydelendik

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2272)
<!-- Reviewable:end -->
