### PR TITLE
Remove `x` flag from flags string before invoking native RegExp ctor in ASRegExp ctor

### DIFF
--- a/src/avm2/nat.ts
+++ b/src/avm2/nat.ts
@@ -1841,6 +1841,7 @@ module Shumway.AVMX.AS {
                 // With the x flag set, spaces in the regular expression, will be ignored as part of
                 // the pattern.
                 this._extended = true;
+                break;
               case 'g':
               case 'i':
               case 'm':


### PR DESCRIPTION
trivial, r=me

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2275)
<!-- Reviewable:end -->
