### PR TITLE
Moves acid-morph stas test to the tracetest.

### DIFF
--- a/test/test_manifest.json
+++ b/test/test_manifest.json
@@ -203,13 +203,6 @@
       "swf": "swfs/acid/acid-morph.swf",
       "type": "eq"
     },
-    {  "id": "acid-morph-stas",
-      "stas": "swfs/trace.stas",
-      "filenames": [
-        "swfs/acid/acid-morph.swf"
-      ],
-      "type": "stas"
-    },
     {  "id": "getObjectsUnderPoint",
       "stas": "swfs/trace.stas",
       "filenames": [

--- a/test/test_manifest_trace.json
+++ b/test/test_manifest_trace.json
@@ -49,6 +49,13 @@
       ],
       "type": "stas"
     },
+    {  "id": "acid",
+      "stas": "swfs/trace.stas",
+      "filenames": [
+        "swfs/acid/acid-morph.swf"
+      ],
+      "type": "stas"
+    },
     {  "id": "flash_events_Event trace",
        "stas": "swfs/trace.stas",
        "filenames": [


### PR DESCRIPTION
To avoid intermittent failures on botio: 

```
TEST-UNEXPECTED-FAIL | stas acid-morph-stas  | in firefox | trace of 1 != reference trace
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2290)
<!-- Reviewable:end -->
