### PR TITLE
Removes shumway.userInputSecurity option.

### DIFF
--- a/extension/firefox/content/web/viewerGfx.js
+++ b/extension/firefox/content/web/viewerGfx.js
@@ -16,15 +16,6 @@
 
 var SHUMWAY_ROOT = "resource://shumway/";
 
-function notifyUserInput() {
-  ShumwayCom.userInput();
-}
-
-document.addEventListener('mousedown', notifyUserInput, true);
-document.addEventListener('mouseup', notifyUserInput, true);
-document.addEventListener('keydown', notifyUserInput, true);
-document.addEventListener('keyup', notifyUserInput, true);
-
 var easel;
 function createEasel(backgroundColor) {
   var Stage = Shumway.GFX.Stage;

--- a/src/base/external.ts
+++ b/src/base/external.ts
@@ -20,7 +20,6 @@ declare var ShumwayCom: {
   createRtmpXHR: () => RtmpXHR;
   createSpecialStorage: () => SpecialStorage;
   getWeakMapKeys: (weakMap) => Array<any>;
-  userInput: () => void;
   fallback: () => void;
   reportIssue: (details?: string) => void;
   reportTelemetry: (data) => void;


### PR DESCRIPTION
The nsIDOMWindowUtils.isHandlingUserInput shall be called in the same process where event was fired.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2297)
<!-- Reviewable:end -->
