### PR TITLE
Add Flash base param support to shuobject

### DIFF
--- a/extension/shuobject/shuobject.js
+++ b/extension/shuobject/shuobject.js
@@ -320,6 +320,7 @@ var shuobject = (function () {
     }
 
     var objectParams = {};
+    var flashBase;
     if (params) {
       Object.keys(params).forEach(function (name) {
         name = name.toLowerCase();
@@ -327,6 +328,9 @@ var shuobject = (function () {
           if (!flashvars) {
             flashvars = parseQueryString(params[name]);
           }
+        } else if (name === 'base') {
+          // Base param, send as baseUrl in pluginParams below
+          flashBase = combineUrl(getDocumentBase(), params[name]);
         }
         objectParams[name] = params[name];
       });
@@ -344,7 +348,7 @@ var shuobject = (function () {
     }
 
     var pluginParams = {
-      baseUrl: getDocumentBase(),
+      baseUrl: flashBase || getDocumentBase(),
       url: absoluteSwfUrl,
       movieParams: movieParams,
       objectParams: objectParams,


### PR DESCRIPTION
Shuobject before appeared to just be passing the document base as the flash base to the created iframe. Now, if set, it will pass the absolute URL version of params['base']; otherwise it'll just pass getDocumentBase() as it did before.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2312)
<!-- Reviewable:end -->
