### PR TITLE
Bug 1148805 - Cache MovieClip child names in AVM1MovieClip for faster lookup

### DIFF
--- a/src/avm1/lib/AVM1Utils.ts
+++ b/src/avm1/lib/AVM1Utils.ts
@@ -29,6 +29,7 @@ module Shumway.AVM1.Lib {
     context: AVM1Context;
     initAVM1SymbolInstance(context: AVM1Context, as3Object: flash.display.InteractiveObject);
     updateAllEvents();
+    getDepth(): number;
   }
 
   export class AVM1EventHandler {
@@ -65,6 +66,11 @@ module Shumway.AVM1.Lib {
 
       release || Debug.assert(as3Object);
       this._as3Object = as3Object;
+      var name = this.as3Object.name;
+      var parent = this.get_parent();
+      if (name && parent) {
+        parent._addChildName(this, name);
+      }
     }
 
     private _getAS3ObjectTemplate(): T {
@@ -270,7 +276,9 @@ module Shumway.AVM1.Lib {
 
     public set_name(value: string) {
       value = alCoerceString(this.context, value);
+      var oldName = this.as3Object.name;
       this.as3Object.name = value;
+      this.get_parent()._updateChildName(<AVM1MovieClip><any>this, oldName, value);
     }
 
     public get_parent(): AVM1MovieClip {

--- a/src/flash/avm1.d.ts
+++ b/src/flash/avm1.d.ts
@@ -39,6 +39,8 @@ declare module Shumway.AVM1 {
                                   placeObjectTag: Shumway.SWF.Parser.PlaceObjectTag): void;
     class AVM1MovieClip extends AVM1Object {
       setParameters(parameters: any): void;
+      _removeChildName(child: AVM1Object, name: string): void;
+      context: AVM1Context;
     }
   }
 }

--- a/src/flash/display/DisplayObject.ts
+++ b/src/flash/display/DisplayObject.ts
@@ -1536,6 +1536,7 @@ module Shumway.AVMX.AS.flash.display {
     set name(value: string) {
       checkNullParameter(value, "name", this.sec);
       if (this._hasFlags(DisplayObjectFlags.OwnedByTimeline)) {
+        // In AVM2, setting the name of a timline-placed DisplayObject throws.
         if (this._symbol && !this._symbol.isAVM1Object) { // fail only in AVM2
           this.sec.throwError('IllegalOperationError', Errors.TimelineObjectNameSealedError);
         }

--- a/src/flash/display/DisplayObjectContainer.ts
+++ b/src/flash/display/DisplayObjectContainer.ts
@@ -484,7 +484,7 @@ module Shumway.AVMX.AS.flash.display {
             !(options & LookupChildOptions.INCLUDE_NON_INITIALIZED)) {
           continue;
         }
-        if (child.name === name) {
+        if (child._name === name) {
           return child;
         }
       }
@@ -501,7 +501,7 @@ module Shumway.AVMX.AS.flash.display {
           !(options & LookupChildOptions.INCLUDE_NON_INITIALIZED)) {
           continue;
         }
-        if (child.name.toLowerCase() === name) {
+        if (child._name.toLowerCase() === name) {
           return child;
         }
       }

--- a/src/flash/display/MovieClip.ts
+++ b/src/flash/display/MovieClip.ts
@@ -342,6 +342,24 @@ module Shumway.AVMX.AS.flash.display {
       this.addEventListener('enterFrame', enterFrameListener);
     }
 
+    /**
+     * Field holding the as2 object associated with this MovieClip instance.
+     *
+     * This field is only ever populated by the AVM1 runtime, so can only be used for MovieClips
+     * used in the implementation of an AVM1 display list.
+     */
+    private _as2Object: AVM1.Lib.AVM1MovieClip;
+
+    removeChildAt(index: number): DisplayObject {
+      var child = super.removeChildAt(index);
+      if (this._as2Object && child._name) {
+        var avm1Child = AVM1.Lib.getAVM1Object(child, this._as2Object.context);
+        // Not all display objects are reflected in AVM1, so not all need to be removed.
+        avm1Child && this._as2Object._removeChildName(avm1Child, child._name);
+      }
+      return child;
+    }
+
     constructor () {
       super();
       if (!this._fieldsInitialized) {


### PR DESCRIPTION
This patch reduces the time we spend under DisplayObject.performFrameNavigation during each turn of the event loop from ~1450ms to ~90ms on my machine, with the devtools profiler open. It's not the prettiest thing in the world, but also not so bad, and fairly small. See patch comment for details.

r? @yurydelendik.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2334)
<!-- Reviewable:end -->
