### PR TITLE
Bug 1148805 - Correctly handle undefined/null values when trying to convert AVM1 filters to AVM2 instances

### DIFF
--- a/src/avm1/lib/AVM1Filters.ts
+++ b/src/avm1/lib/AVM1Filters.ts
@@ -243,7 +243,7 @@ module Shumway.AVM1.Lib {
     'GradientBevelFilter', 'GradientGlowFilter'];
 
   export function convertToAS3Filter(context: AVM1Context, as2Filter: AVM1Object): ASObject {
-    var proto = as2Filter.alPrototype;
+    var proto = as2Filter ? as2Filter.alPrototype : null;
     while (proto && !(<AVM1BitmapFilterPrototype>proto).asFilterConverter) {
       proto = proto.alPrototype;
     }
@@ -263,7 +263,7 @@ module Shumway.AVM1.Lib {
         }
       }
     }
-    return context.sec.createArray(arr);
+    return context.sec.createArrayUnsafe(arr);
   }
 
   export function convertFromAS3Filters(context: AVM1Context, as3Filters: ASObject): AVM1Object {


### PR DESCRIPTION
This eliminates another slowdown in the SWF: a never-ending barrage of errors caused by us not properly handling undefined filters in the conversion from AVM1 to AVM2.

r? @yurydelendik

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2335)
<!-- Reviewable:end -->
