### PR TITLE
Bug 1193595 - Disables XPI verification during testing.

### DIFF
--- a/test/resources/firefox/prefs.js
+++ b/test/resources/firefox/prefs.js
@@ -3,6 +3,7 @@ user_pref("extensions.ui.lastCategory", "addons://list/extension");
 user_pref("browser.rights.3.shown", true);
 user_pref("shumway.ignoreCTP", true);
 user_pref("shumway.environment", "test");
+user_pref("xpinstall.signatures.required", false);
 user_pref("browser.displayedE10SPrompt", 5);
 user_pref("browser.displayedE10SPrompt.1", 5);
 user_pref("browser.displayedE10SNotice", 2);


### PR DESCRIPTION
Fixes https://bugzilla.mozilla.org/show_bug.cgi?id=1193595

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2338)
<!-- Reviewable:end -->
