### PR TITLE
Bug 1148805 - Only warn for valid but buggy AVM1 code if warning flag is set

### DIFF
--- a/src/avm1/interpreter.ts
+++ b/src/avm1/interpreter.ts
@@ -40,7 +40,9 @@ module Shumway.AVM1 {
         throw new Error(message); // using throw as a way to break in browsers debugger
       } catch (e) { /* ignoring since handled */ }
     }
-    Debug.warning.apply(console, arguments);
+    if (avm1WarningsEnabled.value) {
+      Debug.warning.apply(console, arguments);
+    }
   }
 
   export var MAX_AVM1_HANG_TIMEOUT = 1000;

--- a/src/avm1/settings.ts
+++ b/src/avm1/settings.ts
@@ -24,6 +24,7 @@ module Shumway.AVM1 {
   var avm1Options = shumwayOptions.register(new OptionSet("AVM1"));
   export var avm1TraceEnabled = avm1Options.register(new Option("t1", "traceAvm1", "boolean", false, "trace AVM1 execution"));
   export var avm1ErrorsEnabled = avm1Options.register(new Option("e1", "errorsAvm1", "boolean", false, "fail on AVM1 warnings and errors"));
+  export var avm1WarningsEnabled = avm1Options.register(new Option("w1", "warningsAvm1", "boolean", false, "Emit messages for AVM1 warnings and errors"));
   export var avm1TimeoutDisabled = avm1Options.register(new Option("ha1", "nohangAvm1", "boolean", false, "disable fail on AVM1 hang"));
   export var avm1CompilerEnabled = avm1Options.register(new Option("ca1", "compileAvm1", "boolean", true, "compiles AVM1 code"));
   export var avm1DebuggerEnabled = avm1Options.register(new Option("da1", "debugAvm1", "boolean", false, "allows AVM1 code debugging"));


### PR DESCRIPTION
The warnings can cause serious slowdowns, because they sometimes stringify complex objects, so they shouldn't happen in release builds.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2339)
<!-- Reviewable:end -->
