### PR TITLE
Always allocate PreRenderState through pool, and ensure this won't cause further leaks

### DIFF
--- a/src/gfx/nodes.ts
+++ b/src/gfx/nodes.ts
@@ -230,12 +230,14 @@ module Shumway.GFX {
 
   export class PreRenderState extends State {
     private static _dirtyStack: PreRenderState [] = [];
+    private static _doNotCallCtorDirectly = Object.create(null);
 
     matrix: Matrix = Matrix.createIdentity();
     depth: number = 0;
 
-    constructor() {
+    constructor(unlock: any) {
       super();
+      release || assert(unlock === PreRenderState._doNotCallCtorDirectly);
     }
 
     transform(transform: Transform): PreRenderState {
@@ -249,15 +251,15 @@ module Shumway.GFX {
       var state = null;
       if (dirtyStack.length) {
         state = dirtyStack.pop();
+      } else {
+        state = new PreRenderState(this._doNotCallCtorDirectly);
       }
       return state;
     }
 
     public clone(): PreRenderState {
       var state = PreRenderState.allocate();
-      if (!state) {
-        state = new PreRenderState();
-      }
+      release || assert(state);
       state.set(this);
       return state;
     }
@@ -281,7 +283,7 @@ module Shumway.GFX {
 
     start(node: Group, dirtyRegion: DirtyRegion) {
       this._dirtyRegion = dirtyRegion;
-      var state = new PreRenderState();
+      var state = PreRenderState.allocate();
       state.matrix.setIdentity();
       node.visit(this, state);
       state.free();


### PR DESCRIPTION
We had an ever so small leak that's fixed by this: http://i.imgur.com/nbBRzOT.png

(In case the image goes away: my dev browser instance used 53GB after letting a SWF of medium complexity run for a few hours.)

r? @yurydelendik

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2340)
<!-- Reviewable:end -->
