### PR TITLE
Avoid error when enumerating of undefined value in AVM1.

### DIFF
--- a/src/avm1/interpreter.ts
+++ b/src/avm1/interpreter.ts
@@ -1734,6 +1734,11 @@ module Shumway.AVM1 {
         return;
       }
       var obj = resolved.value;
+      if (isNullOrUndefined(obj)) {
+        avm1Warn("AVM1 warning: cannot iterate over undefined object");
+        return;
+      }
+
       as2Enumerate(obj, function (name) {
         stack.push(name);
       }, null);


### PR DESCRIPTION
Converts the error in http://swf.codeazur.com.br/archive/dd/43/69/e2/dd4369e279f78efb970c33253526995445da581e0042d12ebf875e9da2b8935b.swf to a warning.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2343)
<!-- Reviewable:end -->
