### PR TITLE
Clone buffers containing serialized GFX responses into player compartment before use

### DIFF
--- a/src/base/dataBuffer.ts
+++ b/src/base/dataBuffer.ts
@@ -145,6 +145,22 @@ module Shumway.ArrayUtilities {
     }
 
     /**
+     * Clone the DataBuffer in a way that guarantees the underlying ArrayBuffer to be copied
+     * into an instance of the current global's ArrayBuffer.
+     *
+     * Important if the underlying buffer comes from a different global, in which case accessing
+     * its elements is excruiciatingly slow.
+     */
+    clone(): DataBuffer {
+      var clone = DataBuffer.FromArrayBuffer(new Uint8Array(this._u8).buffer, this._length);
+      clone._position = this._position;
+      clone._littleEndian = this._littleEndian;
+      clone._bitBuffer = this._bitBuffer;
+      clone._bitLength = this._bitLength;
+      return clone;
+    }
+
+    /**
      * By default, we only have a byte view. All other views are |null|.
      */
     private _resetViews() {

--- a/src/player/player.ts
+++ b/src/player/player.ts
@@ -424,7 +424,7 @@ module Shumway.Player {
       if (async) {
         this._gfxService.update(serializer.output, serializer.outputAssets);
       } else {
-        output = this._gfxService.updateAndGet(serializer.output, serializer.outputAssets);
+        output = this._gfxService.updateAndGet(serializer.output, serializer.outputAssets).clone();
       }
       leaveTimeline("remoting assets");
 
@@ -435,7 +435,7 @@ module Shumway.Player {
       var serializer = new Remoting.Player.PlayerChannelSerializer();
       serializer.writeRequestBitmapData(bitmapData);
       serializer.writeEOF();
-      return this._gfxService.updateAndGet(serializer.output, serializer.outputAssets);
+      return this._gfxService.updateAndGet(serializer.output, serializer.outputAssets).clone();
     }
 
     public drawToBitmap(bitmapData: flash.display.BitmapData, source: Shumway.Remoting.IRemotable,


### PR DESCRIPTION
This fixes a truly bad performance fault in handling of `BitmapData` data.

r? @mbebenita

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2347)
<!-- Reviewable:end -->
