### PR TITLE
navigateTo regression and cleanup in the extension

### DIFF
--- a/extension/firefox/chrome/ShumwayCom.jsm
+++ b/extension/firefox/chrome/ShumwayCom.jsm
@@ -597,9 +597,9 @@ ShumwayChromeActions.prototype = {
         return;
     }
     var isJavaScriptURL = scheme === "javascript";
-    if (!this.allowScriptAccess &&
-        isJavaScriptURL ||
-        (target === '_top' || target === '_parent')) {
+    var requireScriptAccess = isJavaScriptURL ||
+                              (target === '_top' || target === '_parent');
+    if (!this.allowScriptAccess && requireScriptAccess) {
       return;
     }
     // ...and only when user input is in-progress.


### PR DESCRIPTION
Clicking links stopped working in http://flashcartoons.org/. There were forgotten parenthesis in logical operators. Making it more clear.

(Also PlayPreview cleanup)

r? @tschneidereit

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2357)
<!-- Reviewable:end -->
