### PR TITLE
AVM1: Normalize name in alPut

### DIFF
--- a/src/avm1/interpreter.ts
+++ b/src/avm1/interpreter.ts
@@ -416,7 +416,6 @@ module Shumway.AVM1 {
 
   function as2GetProperty(context: AVM1Context, obj: any, name: any): any {
     var avm1Obj: AVM1Object = alToObject(context, obj);
-    name = alNormalizeName(context, name);
     return avm1Obj.alGet(name);
   }
 

--- a/src/avm1/runtime.ts
+++ b/src/avm1/runtime.ts
@@ -239,7 +239,8 @@ module Shumway.AVM1 {
     }
 
     public alGet(p): any {
-      var desc = this.alGetProperty(p);
+      name = alNormalizeName(this.context, p);
+      var desc = this.alGetProperty(name);
       if (!desc) {
         return undefined;
       }


### PR DESCRIPTION
There are too many callsites that don't necessarily normalize the name, so not doing it here is quite fragile.

Fixes a regression where using the mouse in SWFs with versions < 7 caused failing asserts. r=regression

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2369)
<!-- Reviewable:end -->
