### PR TITLE
Catch errors in child constructors in DisplayObjectContainer#_constructChildren

### DIFF
--- a/src/flash/display/DisplayObjectContainer.ts
+++ b/src/flash/display/DisplayObjectContainer.ts
@@ -92,7 +92,11 @@ module Shumway.AVMX.AS.flash.display {
         if (child._hasFlags(DisplayObjectFlags.Constructed)) {
           continue;
         }
-        (<any>child).axInitializer();
+        try {
+          (<any>child).axInitializer();
+        } catch (e) {
+          Debug.warning('caught error executing child constructor in constructChildren: ', e);
+        }
         //child.class.instanceConstructorNoInitialize.call(child);
         child._removeReference();
         if (child._name) {


### PR DESCRIPTION
Just like for events dispatched by phases of the event loop, exceptions from inside/under hook functions shouldn't propagate up. r=trivial

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2372)
<!-- Reviewable:end -->
