### PR TITLE
Fixes loaderURL inspector setting.

### DIFF
--- a/src/player/player.ts
+++ b/src/player/player.ts
@@ -384,7 +384,7 @@ module Shumway.Player {
 
     public load(url: string, buffer?: ArrayBuffer) {
       release || assert (!this._loader, "Can't load twice.");
-      this._swfUrl = this._loaderUrl = url;
+      this._swfUrl = url;
       this._stage = new this.sec.flash.display.Stage();
       var loader = this._loader = this.sec.flash.display.Loader.axClass.getRootLoader();
       var loaderInfo = this._loaderInfo = loader.contentLoaderInfo;


### PR DESCRIPTION
In the inspector, the loaderURL got broken -- fixing that. Trivial.

(Regression after ee841054353386e947a93001848cd45ac91fd0c3)
<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2374)
<!-- Reviewable:end -->
