### PR TITLE
Disable pretty-printing in closure optimizations

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -434,7 +434,6 @@ module.exports = function(grunt) {
     // This needs a special build of closure that has SHUMWAY_OPTIMIZATIONS.
     var closureCmd = 'java';
     var closureArgs = ['-jar', 'utils/closure.jar',
-      '--formatting', 'PRETTY_PRINT',
       '--define', 'release=true',
       '--compilation_level', 'SHUMWAY_OPTIMIZATIONS',
       '--language_in', 'ECMASCRIPT5'];


### PR DESCRIPTION
Reduces JS file sizes by ~35% and XPI size by about 50kb (~7.5%).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2377)
<!-- Reviewable:end -->
