### PR TITLE
Support playback of base64-encoded SWFM files

### DIFF
--- a/examples/swfmplayer/swfmPlayer.js
+++ b/examples/swfmplayer/swfmPlayer.js
@@ -37,6 +37,7 @@ var queryVariables = parseQueryString(window.location.search);
 var movieURL = queryVariables['swfm'] || 'tiger.swfm';
 var scoreRun = queryVariables['score'] === 'true';
 var fastRun = queryVariables['fast'] === 'true';
+var preview = queryVariables['preview'] === 'true';
 var easelHost;
 
 function startMovie(file) {
@@ -56,6 +57,42 @@ function startMovie(file) {
     };
   } else {
     easel.startRendering();
+    if (preview) {
+      easelHost.useIntrinsicSize = true;
+      var currentFrame = 0;
+      var currentPosition = 0;
+      var cpuTime = 0;
+      var previews = document.getElementById('previews');
+      var frames = [];
+      easelHost.onFrame = function () {
+        var frame = document.createElement('div');
+        currentFrame++;
+        var frameSize = easelHost.currentPosition - currentPosition;
+        currentPosition += frameSize;
+        var frameTime = easelHost.cpuTime - cpuTime;
+        cpuTime += frameTime;
+        frame.innerHTML = 'Frame ' + currentFrame + ' (size: ' + frameSize + ', render time: ' +
+                          frameTime.toPrecision(2) + '):';
+        var img = new Image();
+        img.src = easel.screenShot(null, true, true).dataURL;
+        frame.insertBefore(img, frame.firstChild);
+        frames.push(frame);
+      };
+      document.body.onscroll = function() {
+        if (!frames.length) {
+          return;
+        }
+        var currentFrame = previews.firstChild;
+        currentFrame && previews.removeChild(currentFrame);
+        previews.appendChild(frames[0]);
+        //if (previews.style.width === '') {
+        //  previews.style.width = img.width + 'px';
+        //  previews.style.height = img.height + 'px';
+        //}
+        "use strict";
+        console.log('scr')
+      }
+    }
   }
 }
 

--- a/src/gfx/easel.ts
+++ b/src/gfx/easel.ts
@@ -336,7 +336,7 @@ module Shumway.GFX {
 
       this._renderer = new Canvas2D.Canvas2DRenderer(stageContainer, this._stage, this._options);
       this._listenForContainerSizeChanges();
-      this._onMouseUp = this._onMouseUp.bind(this)
+      this._onMouseUp = this._onMouseUp.bind(this);
       this._onMouseDown = this._onMouseDown.bind(this);
       this._onMouseMove = this._onMouseMove.bind(this);
 
@@ -384,6 +384,11 @@ module Shumway.GFX {
           self._persistentState.onKeyUp(self, event);
         }
       }, false);
+    }
+
+    setSize(width: number, height: number) {
+      this._container.style.width = width + 'px';
+      this._container.style.height = height + 'px';
     }
 
     private _listenForContainerSizeChanges() {

--- a/src/gfx/easelHost.ts
+++ b/src/gfx/easelHost.ts
@@ -35,7 +35,7 @@ module Shumway.GFX {
     private _easel: Easel;
     private _group: Group;
     private _context: Shumway.Remoting.GFX.GFXChannelDeserializerContext;
-    private _content: Group;
+    protected _content: Group;
     private _fullscreen: boolean;
 
     constructor(easel: Easel) {

--- a/src/gfx/test/playbackEaselHost.ts
+++ b/src/gfx/test/playbackEaselHost.ts
@@ -25,6 +25,21 @@ module Shumway.GFX.Test {
 
   var MINIMAL_TIMER_INTERVAL = 5;
 
+  export function playBase64SWFM(containerID: string, swfm: string) {
+    var container: HTMLDivElement = <HTMLDivElement>document.getElementById(containerID);
+    if (!container) {
+      throw new Error('DIV with id "' + containerID + '" not found');
+    }
+    if (!swfm || typeof swfm !== 'string') {
+      throw new Error("No base64-encoded SWFM file provided");
+    }
+    var easel = new Shumway.GFX.Easel(container);
+    var easelHost = new PlaybackEaselHost(easel);
+    easelHost.useIntrinsicSize = true;
+    easelHost.playBytes(Shumway.StringUtilities.decodeRestrictedBase64ToBytes(swfm));
+    easel.startRendering();
+  }
+
   export class PlaybackEaselHost extends EaselHost {
     private _parser: MovieRecordParser;
     private _lastTimestamp: number;

--- a/src/gfx/test/recorder.ts
+++ b/src/gfx/test/recorder.ts
@@ -296,6 +296,10 @@ module Shumway.GFX.Test {
       this._buffer.position = 4;
     }
 
+    public get position(): number {
+      return this._buffer.position;
+    }
+
     public readNextRecord(): MovieRecordType  {
       if (this._buffer.position >= this._buffer.length) {
         return MovieRecordType.None;


### PR DESCRIPTION
To enable almost-fully self-contained HTML files that only need the GFX bundle as a runtime, nothing more.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2392)

<!-- Reviewable:end -->
