### PR TITLE
Use ThreadSafeChromeUtils.nondeterministicGetWeakMapKeys. Fixes #2416.

### DIFF
--- a/extension/firefox/chrome/ShumwayCom.jsm
+++ b/extension/firefox/chrome/ShumwayCom.jsm
@@ -349,7 +349,7 @@ var ShumwayCom = {
       },
 
       getWeakMapKeys: function (weakMap) {
-        var keys = Components.utils.nondeterministicGetWeakMapKeys(weakMap);
+        var keys = ThreadSafeChromeUtils.nondeterministicGetWeakMapKeys(weakMap);
         var result = new content.Array();
         keys.forEach(function (key) {
           result.push(key);


### PR DESCRIPTION
Components.utils.nondeterministicGetWeakMapKeys was removed:
https://hg.mozilla.org/mozilla-central/rev/7c22b95c0e29

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/shumway/2417)
<!-- Reviewable:end -->
