### PR TITLE
Fix windows build

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -15,3 +15,4 @@ Jeff Dyer
 Till Schneidereit <tschneidereit@mozilla.com>
 Jet Villegas <jet@mozilla.com>
 Claus Wahlers <cwahlers@mozilla.com>
+ExE Boss

--- a/utils/update-flash-refs.js
+++ b/utils/update-flash-refs.js
@@ -191,7 +191,7 @@ function packageRefs(includes, output, license) {
       '\n';
   });
   var content = '', included = {};
-  refs.split('\n').forEach(function (entry) {
+  refs.split(/\r\n|\r|\n/).forEach(function (entry) {
     if (entry.trim() === '') {
       return;
     }


### PR DESCRIPTION
Fixes the `\r` symbol remaining at the end of `entry` in the file `utils/update-flash-refs.js:194`, which resulted in the build not working on Windows.