### PR TITLE
Make set color behavior conform to AS3 spec

### DIFF
--- a/src/flash/geom/ColorTransform.ts
+++ b/src/flash/geom/ColorTransform.ts
@@ -147,7 +147,7 @@ module Shumway.AVMX.AS.flash.geom {
       this.redOffset = (newColor >> 16) & 0xff;
       this.greenOffset = (newColor >> 8) & 0xff;
       this.blueOffset = newColor & 0xff;
-      this.redMultiplier = this.greenMultiplier = this.blueMultiplier = 1;
+      this.redMultiplier = this.greenMultiplier = this.blueMultiplier = 0;
     }
 
     public concat(second: ColorTransform): void {


### PR DESCRIPTION
According to the docs, setting color should reset the multipliers 0 not 1
http://help.adobe.com/en_US/FlashPlatform/reference/actionscript/3/flash/geom/ColorTransform.html#color