### PR TITLE
Fix PNG color type read

### DIFF
--- a/src/swf/parser/image.ts
+++ b/src/swf/parser/image.ts
@@ -90,7 +90,7 @@ module Shumway.SWF.Parser {
     }
     image.width = readInt32(bytes, ihdrOffset + 4);
     image.height = readInt32(bytes, ihdrOffset + 8);
-    var type = bytes[ihdrOffset + 14];
+    var type = bytes[ihdrOffset + 13];
     image.hasAlpha = type === 4 || type === 6;
   }
 


### PR DESCRIPTION
The color type is the byte at offset 9 in the IHDR PNG chunk
(offset 13 from the chunk size and 25 since the start of the file).
Shumway was incorrectly reading the byte 14 corresponding to the
compression method.

- See https://www.w3.org/TR/PNG/#11IHDR