### PR TITLE
Fix check for existing listener

### DIFF
--- a/src/flash/events/EventDispatcher.ts
+++ b/src/flash/events/EventDispatcher.ts
@@ -60,7 +60,9 @@ module Shumway.AVMX.AS.flash.events {
         if (priority > entry.priority) {
           index = i;
         } else {
-          break;
+          if (priority < entry.priority) {
+            break;
+          }
         }
       }
       entries = this.ensureNonAliasedEntries();


### PR DESCRIPTION
The following code adds `handler` two times:

```ts
d.addEventListener(Event.COMPLETE, handler);
d.addEventListener(Event.COMPLETE, handler2);
d.addEventListener(Event.COMPLETE, handler);
```